### PR TITLE
feat: crear record inmutable DBConfig

### DIFF
--- a/src/main/java/com/sisinf/estante/config/DBConfig.java
+++ b/src/main/java/com/sisinf/estante/config/DBConfig.java
@@ -1,0 +1,34 @@
+package com.sisinf.estante.config;
+
+/**
+ *
+ * @param host     Dirección del servidor de base de datos
+ * @param puerto   Puerto de conexión
+ * @param nombre   Nombre de la base de datos
+ * @param usuario  Usuario de conexión
+ * @param password Contraseña de conexión
+ */
+public record DBConfig(
+        String host,
+        int puerto,
+        String nombre,
+        String usuario,
+        String password
+) {
+    /**
+     */
+    public DBConfig {
+        if (host == null) throw new IllegalArgumentException("host no puede ser nulo");
+        if (nombre == null) throw new IllegalArgumentException("nombre no puede ser nulo");
+        if (usuario == null) throw new IllegalArgumentException("usuario no puede ser nulo");
+        if (password == null) throw new IllegalArgumentException("password no puede ser nulo");
+    }
+
+    /**
+     *
+     * @return 
+     */
+    public String toJdbcUrl() {
+        return "jdbc:mysql://" + host + ":" + puerto + "/" + nombre;
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea un record inmutable `DBConfig` para almacenar la configuración de conexión a la base de datos (host, puerto, nombre, usuario y password), con validación básica en el constructor y método `toJdbcUrl()`.

## Issue relacionado
Closes #

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Archivo creado: `src/main/java/com/sisinf/estante/config/DBConfig.java`
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0f9f0bfc-0382-4317-b26d-fe479be47fe1" />
