### PR TITLE
Feat/record dbconfig

### DIFF
--- a/src/main/java/com/sisinf/estante/config/DBConfig.java
+++ b/src/main/java/com/sisinf/estante/config/DBConfig.java
@@ -1,12 +1,13 @@
 package com.sisinf.estante.config;
 
 /**
+ * Configuración de conexión a base de datos.
  *
- * @param host     Dirección del servidor de base de datos
- * @param puerto   Puerto de conexión
- * @param nombre   Nombre de la base de datos
- * @param usuario  Usuario de conexión
- * @param password Contraseña de conexión
+ * @param host Dirección del servidor
+ * @param puerto Puerto de conexión
+ * @param nombre Nombre de la base de datos
+ * @param usuario Usuario de acceso
+ * @param password Contraseña
  */
 public record DBConfig(
         String host,
@@ -15,18 +16,28 @@ public record DBConfig(
         String usuario,
         String password
 ) {
-    /**
-     */
+
     public DBConfig {
-        if (host == null) throw new IllegalArgumentException("host no puede ser nulo");
-        if (nombre == null) throw new IllegalArgumentException("nombre no puede ser nulo");
-        if (usuario == null) throw new IllegalArgumentException("usuario no puede ser nulo");
-        if (password == null) throw new IllegalArgumentException("password no puede ser nulo");
+        if (host == null || host.isBlank())
+            throw new IllegalArgumentException("host no puede estar vacío");
+
+        if (puerto <= 0)
+            throw new IllegalArgumentException("puerto inválido");
+
+        if (nombre == null || nombre.isBlank())
+            throw new IllegalArgumentException("nombre no puede estar vacío");
+
+        if (usuario == null || usuario.isBlank())
+            throw new IllegalArgumentException("usuario no puede estar vacío");
+
+        if (password == null)
+            throw new IllegalArgumentException("password no puede ser nulo");
     }
 
     /**
+     * Genera la URL JDBC para MySQL.
      *
-     * @return 
+     * @return URL JDBC
      */
     public String toJdbcUrl() {
         return "jdbc:mysql://" + host + ":" + puerto + "/" + nombre;

--- a/src/main/java/com/sisinf/estante/config/DBConfig.java
+++ b/src/main/java/com/sisinf/estante/config/DBConfig.java
@@ -1,0 +1,34 @@
+package com.sisinf.estante.config;
+
+/**
+ *
+ * @param host     Dirección del servidor de base de datos
+ * @param puerto   Puerto de conexión
+ * @param nombre   Nombre de la base de datos
+ * @param usuario  Usuario de conexión
+ * @param password Contraseña de conexión
+ */
+public record DBConfig(
+        String host,
+        int puerto,
+        String nombre,
+        String usuario,
+        String password
+) {
+    /**
+     */
+    public DBConfig {
+        if (host == null) throw new IllegalArgumentException("host no puede ser nulo");
+        if (nombre == null) throw new IllegalArgumentException("nombre no puede ser nulo");
+        if (usuario == null) throw new IllegalArgumentException("usuario no puede ser nulo");
+        if (password == null) throw new IllegalArgumentException("password no puede ser nulo");
+    }
+
+    /**
+     *
+     * @return 
+     */
+    public String toJdbcUrl() {
+        return "jdbc:mysql://" + host + ":" + puerto + "/" + nombre;
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el record inmutable DBConfig para manejar configuraciones de conexión a base de datos.

## Issue relacionado
Closes #75

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/33994490-51cd-4578-92e3-b2fb52b0d93c" />
