### PR TITLE
docs: corregir diccionario de datos con enfoque técnico DBMS #47

### DIFF
--- a/docs/diccionario-datos.md
+++ b/docs/diccionario-datos.md
@@ -1,17 +1,14 @@
 # Diccionario de Datos - DBMS Estante
 
-Este documento detalla la estructura lógica del sistema, definiendo los tipos de datos y restricciones de integridad del motor de base de datos.
-
-## Tabla: LIBROS (Entidad de Almacenamiento)
+## Tabla: LIBROS
 | Campo | Tipo | Descripción | Restricciones |
 |---|---|---|---|
-| `id_libro` | INT | Identificador único del registro. | PK, NOT NULL, AUTOINCREMENT |
-| `isbn` | VARCHAR(13) | Código internacional único. | UNIQUE, NOT NULL |
-| `titulo` | VARCHAR(200) | Título almacenado en el buffer. | NOT NULL |
+| `id_libro` | INT | Identificador único. | PK, AUTOINCREMENT |
+| `isbn` | VARCHAR(13) | Código único. | UNIQUE, NOT NULL |
+| `titulo` | VARCHAR(200) | Título del libro. | NOT NULL |
 
-## Tabla: PRESTAMOS (Entidad Transaccional)
+## Tabla: PRESTAMOS
 | Campo | Tipo | Descripción | Restricciones |
 |---|---|---|---|
-| `id_prestamo` | INT | ID de la transacción. | PK, NOT NULL |
-| `id_libro` | INT | Puntero a la tabla LIBROS. | FK, NOT NULL |
-| `fecha_inicio` | DATE | Registro de tiempo de la operación. | NOT NULL |
+| `id_prestamo` | INT | ID Transacción. | PK |
+| `id_libro` | INT | Puntero a LIBROS. | FK |

--- a/docs/diccionario-datos.md
+++ b/docs/diccionario-datos.md
@@ -1,0 +1,17 @@
+# Diccionario de Datos - DBMS Estante
+
+Este documento detalla la estructura lógica del sistema, definiendo los tipos de datos y restricciones de integridad del motor de base de datos.
+
+## Tabla: LIBROS (Entidad de Almacenamiento)
+| Campo | Tipo | Descripción | Restricciones |
+|---|---|---|---|
+| `id_libro` | INT | Identificador único del registro. | PK, NOT NULL, AUTOINCREMENT |
+| `isbn` | VARCHAR(13) | Código internacional único. | UNIQUE, NOT NULL |
+| `titulo` | VARCHAR(200) | Título almacenado en el buffer. | NOT NULL |
+
+## Tabla: PRESTAMOS (Entidad Transaccional)
+| Campo | Tipo | Descripción | Restricciones |
+|---|---|---|---|
+| `id_prestamo` | INT | ID de la transacción. | PK, NOT NULL |
+| `id_libro` | INT | Puntero a la tabla LIBROS. | FK, NOT NULL |
+| `fecha_inicio` | DATE | Registro de tiempo de la operación. | NOT NULL |


### PR DESCRIPTION
## ¿Qué hace este PR?
Se ha reestructurado integralmente el archivo docs/diccionario-datos.md para alinearlo con los requerimientos técnicos de un DBMS (Administrador de Base de Datos). Se definieron las entidades principales con sus respectivos tipos de datos SQL, longitudes de buffer y, fundamentalmente, se estableció la integridad referencial mediante la definición explícita de llaves primarias (PK) y llaves foráneas (FK).

## Issue relacionado
Closes #47
## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
<img width="581" height="348" alt="image" src="https://github.com/user-attachments/assets/59cf48c1-935c-46a6-a9d5-06ee2f6a83e9" />
