### PR TITLE
Fix/docs estandares

### DIFF
--- a/docs/estandares-codigo.md
+++ b/docs/estandares-codigo.md
@@ -8,7 +8,7 @@ Esta guía define convenciones para escribir código Java limpio, consistente y 
 - Usar `PascalCase` (UpperCamelCase).
 - Los nombres deben ser sustantivos.
 - Evitar abreviaciones innecesarias.
-- Cada archivo debe contener una sola clase pública.
+- Cada archivo debe contener una sola clase pública. 
 
 ### ✅ Ejemplos:
 
@@ -161,9 +161,13 @@ public class UserService {
 - 100 caracteres → límite por línea
 - Javadoc → documentación
 - Consistencia > preferencias personales
-- Código → Español
+- Código → Inglés
 
 > [!NOTE]
 > - Los ejemplos presentados son ilustrativos.
 > - No es necesario que el código sea exactamente igual,
 > - pero sí respetar las buenas prácticas descritas.
+
+## 🌐 Idioma utilizado
+
+Se eligió el idioma inglés porque es el estándar en el desarrollo de software y permite mayor consistencia en nombres de clases, métodos y variables.


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige la inconsistencia en el idioma de la documentación de estándares de código.

Se agrega una sección que explica que se utiliza el idioma inglés en nombres de clases, métodos y variables, ya que es el estándar en el desarrollo de software.

## Issue relacionado
Closes #96

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [ ] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica