### PR TITLE
docs: crear diccionario de datos  #47

### DIFF
--- a/docs/diccionario-datos.md
+++ b/docs/diccionario-datos.md
@@ -1,0 +1,36 @@
+# Diccionario de Datos - Proyecto Estante
+
+Este documento describe la estructura de la base de datos relacional utilizada para la gestión de la biblioteca.
+
+## 1. Tabla: `libros`
+Almacena la información bibliográfica de las obras disponibles.
+
+| Columna | Tipo de Dato | Descripción | Restricciones |
+|---|---|---|---|
+| `id_libro` | INTEGER | Identificador único del libro. | PK, AUTOINCREMENT |
+| `titulo` | TEXT | Título de la obra. | NOT NULL |
+| `autor` | TEXT | Nombre del autor. | NOT NULL |
+| `isbn` | TEXT | Código ISBN único de 13 dígitos. | UNIQUE, NOT NULL |
+| `ejemplares` | INTEGER | Cantidad total de copias físicas. | DEFAULT 1 |
+
+## 2. Tabla: `socios`
+Contiene los datos de los usuarios registrados en el sistema.
+
+| Columna | Tipo de Dato | Descripción | Restricciones |
+|---|---|---|---|
+| `id_socio` | INTEGER | Identificador único del socio. | PK, AUTOINCREMENT |
+| `nombre` | TEXT | Nombre completo del usuario. | NOT NULL |
+| `dni` | TEXT | Documento nacional de identidad. | UNIQUE, NOT NULL |
+| `email` | TEXT | Correo electrónico de contacto. | NOT NULL |
+
+## 3. Tabla: `prestamos`
+Registra la relación entre libros y socios, gestionando las fechas de entrega.
+
+| Columna | Tipo de Dato | Descripción | Restricciones |
+|---|---|---|---|
+| `id_prestamo` | INTEGER | Identificador de la transacción. | PK, AUTOINCREMENT |
+| `id_libro` | INTEGER | Referencia al libro prestado. | FK (libros.id_libro) |
+| `id_socio` | INTEGER | Referencia al socio solicitante. | FK (socios.id_socio) |
+| `fecha_salida` | DATE | Fecha en que se entregó el libro. | NOT NULL |
+| `fecha_devolucion` | DATE | Fecha máxima de retorno. | NOT NULL |
+| `estado` | TEXT | Estado del préstamo (Activo/Devuelto). | DEFAULT 'Activo' |

--- a/docs/diccionario-datos.md
+++ b/docs/diccionario-datos.md
@@ -30,4 +30,4 @@ Clasificación lógica de los libros.
 | Nombre Campo | Tipo de Dato | Descripción | Restricciones |
 | :--- | :--- | :--- | :--- |
 | `id_categoria` | INT | Identificador de la categoría. | PK, AUTO_INCREMENT |
-| `nombre` | VARCHAR(100) | Nombre de la categoría (Ingeniería, etc.). | NOT NULL |
+| `nombre` | VARCHAR(100) | Nombre de la categoría (Ingeniería, etc.) | NOT NULL |

--- a/docs/diccionario-datos.md
+++ b/docs/diccionario-datos.md
@@ -1,36 +1,35 @@
-# Diccionario de Datos - Proyecto Estante
+# Diccionario de Datos Técnico - DBMS Estante
 
-Este documento describe la estructura de la base de datos relacional utilizada para la gestión de la biblioteca.
+Este documento detalla el esquema lógico y la estructura de almacenamiento del sistema **Estante**, garantizando la integridad de los datos y la optimización de las consultas.
 
-## 1. Tabla: `libros`
-Almacena la información bibliográfica de las obras disponibles.
+## 1. Tabla: `libros` (Catálogo de Entidades)
+Almacena los registros maestros de los recursos bibliográficos.
 
-| Columna | Tipo de Dato | Descripción | Restricciones |
+| Campo | Tipo de Dato | Tamaño | Descripción | Restricciones |
+|---|---|---|---|---|
+| `id_libro` | INTEGER | 4 bytes | Identificador único de registro. | PK, AUTOINCREMENT |
+| `titulo` | VARCHAR | 255 | Cadena de caracteres para el nombre del recurso. | NOT NULL |
+| `isbn` | VARCHAR | 13 | Índice único para búsqueda rápida por código. | UNIQUE, NOT NULL |
+| `ejemplares` | INT | - | Contador de instancias físicas disponibles. | DEFAULT 1 |
+
+## 2. Tabla: `socios` (Usuarios del Sistema)
+Define la estructura para el almacenamiento de metadatos de los usuarios finales.
+
+| Campo | Tipo de Dato | Tamaño | Descripción | Restricciones |
+|---|---|---|---|---|
+| `id_socio` | INTEGER | 4 bytes | Clave primaria de la entidad usuario. | PK, AUTOINCREMENT |
+| `nombre` | VARCHAR | 100 | Nombre completo registrado en el sistema. | NOT NULL |
+| `dni` | VARCHAR | 20 | Identificador único de identidad (Índice). | UNIQUE, NOT NULL |
+| `email` | VARCHAR | 150 | Punto de contacto para notificaciones del sistema. | NOT NULL |
+
+## 3. Tabla: `prestamos` (Relación de Transacciones)
+Tabla de unión que gestiona las transacciones y la integridad referencial entre libros y socios.
+
+| Campo | Tipo de Dato | Descripción | Restricciones |
 |---|---|---|---|
-| `id_libro` | INTEGER | Identificador único del libro. | PK, AUTOINCREMENT |
-| `titulo` | TEXT | Título de la obra. | NOT NULL |
-| `autor` | TEXT | Nombre del autor. | NOT NULL |
-| `isbn` | TEXT | Código ISBN único de 13 dígitos. | UNIQUE, NOT NULL |
-| `ejemplares` | INTEGER | Cantidad total de copias físicas. | DEFAULT 1 |
-
-## 2. Tabla: `socios`
-Contiene los datos de los usuarios registrados en el sistema.
-
-| Columna | Tipo de Dato | Descripción | Restricciones |
-|---|---|---|---|
-| `id_socio` | INTEGER | Identificador único del socio. | PK, AUTOINCREMENT |
-| `nombre` | TEXT | Nombre completo del usuario. | NOT NULL |
-| `dni` | TEXT | Documento nacional de identidad. | UNIQUE, NOT NULL |
-| `email` | TEXT | Correo electrónico de contacto. | NOT NULL |
-
-## 3. Tabla: `prestamos`
-Registra la relación entre libros y socios, gestionando las fechas de entrega.
-
-| Columna | Tipo de Dato | Descripción | Restricciones |
-|---|---|---|---|
-| `id_prestamo` | INTEGER | Identificador de la transacción. | PK, AUTOINCREMENT |
-| `id_libro` | INTEGER | Referencia al libro prestado. | FK (libros.id_libro) |
-| `id_socio` | INTEGER | Referencia al socio solicitante. | FK (socios.id_socio) |
-| `fecha_salida` | DATE | Fecha en que se entregó el libro. | NOT NULL |
-| `fecha_devolucion` | DATE | Fecha máxima de retorno. | NOT NULL |
-| `estado` | TEXT | Estado del préstamo (Activo/Devuelto). | DEFAULT 'Activo' |
+| `id_prestamo` | INTEGER | Clave primaria de la transacción. | PK, AUTOINCREMENT |
+| `id_libro` | INTEGER | Puntero externo a la tabla `libros`. | FK (libros.id_libro) |
+| `id_socio` | INTEGER | Puntero externo a la tabla `socios`. | FK (socios.id_socio) |
+| `fecha_salida` | DATE | Marca de tiempo de inicio de la transacción. | NOT NULL |
+| `fecha_devolucion` | DATE | Límite temporal de la persistencia del préstamo. | NOT NULL |
+| `estado` | CHAR(1) | Estado lógico del registro (A: Activo, C: Cerrado). | DEFAULT 'A' |

--- a/docs/diccionario-datos.md
+++ b/docs/diccionario-datos.md
@@ -1,35 +1,33 @@
-# Diccionario de Datos Técnico - DBMS Estante
+# Diccionario de Datos - Sistema Estante
 
-Este documento detalla el esquema lógico y la estructura de almacenamiento del sistema **Estante**, garantizando la integridad de los datos y la optimización de las consultas.
+Este documento detalla la estructura de la base de datos para el proyecto Estante, definiendo tipos de datos, longitudes y restricciones de integridad.
 
-## 1. Tabla: `libros` (Catálogo de Entidades)
-Almacena los registros maestros de los recursos bibliográficos.
+## Tabla: LIBROS
+Almacena la información bibliográfica de los textos disponibles en el sistema.
 
-| Campo | Tipo de Dato | Tamaño | Descripción | Restricciones |
-|---|---|---|---|---|
-| `id_libro` | INTEGER | 4 bytes | Identificador único de registro. | PK, AUTOINCREMENT |
-| `titulo` | VARCHAR | 255 | Cadena de caracteres para el nombre del recurso. | NOT NULL |
-| `isbn` | VARCHAR | 13 | Índice único para búsqueda rápida por código. | UNIQUE, NOT NULL |
-| `ejemplares` | INT | - | Contador de instancias físicas disponibles. | DEFAULT 1 |
+| Nombre Campo | Tipo de Dato | Descripción | Restricciones |
+| :--- | :--- | :--- | :--- |
+| `id_libro` | INT | Identificador único del libro. | PK, AUTO_INCREMENT |
+| `isbn` | VARCHAR(13) | Código internacional normalizado. | UNIQUE, NOT NULL |
+| `titulo` | VARCHAR(255) | Título completo de la obra. | NOT NULL |
+| `autor` | VARCHAR(150) | Nombre del autor principal. | NOT NULL |
+| `id_categoria` | INT | Referencia a la categoría. | FK |
 
-## 2. Tabla: `socios` (Usuarios del Sistema)
-Define la estructura para el almacenamiento de metadatos de los usuarios finales.
+## Tabla: PRESTAMOS
+Registra las transacciones de libros entre la biblioteca y los usuarios.
 
-| Campo | Tipo de Dato | Tamaño | Descripción | Restricciones |
-|---|---|---|---|---|
-| `id_socio` | INTEGER | 4 bytes | Clave primaria de la entidad usuario. | PK, AUTOINCREMENT |
-| `nombre` | VARCHAR | 100 | Nombre completo registrado en el sistema. | NOT NULL |
-| `dni` | VARCHAR | 20 | Identificador único de identidad (Índice). | UNIQUE, NOT NULL |
-| `email` | VARCHAR | 150 | Punto de contacto para notificaciones del sistema. | NOT NULL |
+| Nombre Campo | Tipo de Dato | Descripción | Restricciones |
+| :--- | :--- | :--- | :--- |
+| `id_prestamo` | INT | Identificador de la transacción. | PK, AUTO_INCREMENT |
+| `id_libro` | INT | Libro objeto del préstamo. | FK, NOT NULL |
+| `fecha_salida` | DATE | Fecha en que se entrega el libro. | NOT NULL |
+| `fecha_devolucion` | DATE | Fecha pactada de retorno. | NOT NULL |
+| `estado` | VARCHAR(20) | Estado del préstamo (Activo, Devuelto). | DEFAULT 'Activo' |
 
-## 3. Tabla: `prestamos` (Relación de Transacciones)
-Tabla de unión que gestiona las transacciones y la integridad referencial entre libros y socios.
+## Tabla: CATEGORIAS
+Clasificación lógica de los libros.
 
-| Campo | Tipo de Dato | Descripción | Restricciones |
-|---|---|---|---|
-| `id_prestamo` | INTEGER | Clave primaria de la transacción. | PK, AUTOINCREMENT |
-| `id_libro` | INTEGER | Puntero externo a la tabla `libros`. | FK (libros.id_libro) |
-| `id_socio` | INTEGER | Puntero externo a la tabla `socios`. | FK (socios.id_socio) |
-| `fecha_salida` | DATE | Marca de tiempo de inicio de la transacción. | NOT NULL |
-| `fecha_devolucion` | DATE | Límite temporal de la persistencia del préstamo. | NOT NULL |
-| `estado` | CHAR(1) | Estado lógico del registro (A: Activo, C: Cerrado). | DEFAULT 'A' |
+| Nombre Campo | Tipo de Dato | Descripción | Restricciones |
+| :--- | :--- | :--- | :--- |
+| `id_categoria` | INT | Identificador de la categoría. | PK, AUTO_INCREMENT |
+| `nombre` | VARCHAR(100) | Nombre de la categoría (Ingeniería, etc.). | NOT NULL |


### PR DESCRIPTION
## ¿Qué hace este PR?
Se ha creado el archivo técnico docs/diccionario-datos.md que define la estructura lógica y física de la base de datos del sistema Estante. El documento incluye la descripción detallada de las tablas LIBROS, PRESTAMOS y CATEGORIAS, especificando para cada campo su tipo de dato, descripción y las restricciones de integridad correspondientes (PK, FK, NOT NULL).

## Issue relacionado
Closes #47

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
<img width="571" height="600" alt="image" src="https://github.com/user-attachments/assets/c812b85c-7ee0-4714-9bf5-272f0353eb56" />
<img width="602" height="258" alt="image" src="https://github.com/user-attachments/assets/c076fcc1-9adf-436e-84a8-629a62e85515" />
