### PR TITLE
test: configurar JUnit 5 y primera prueba de DBConfig

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,24 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
          http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>edu.sisinf.estante</groupId>
     <artifactId>estante</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
-
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
     </properties>
-
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>
@@ -26,7 +30,11 @@
                     <target>17</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/src/test/java/edu/sisinf/estante/config/DBConfigTest.java
+++ b/src/test/java/edu/sisinf/estante/config/DBConfigTest.java
@@ -1,0 +1,34 @@
+package edu.sisinf.estante.config;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DBConfigTest {
+
+    @Test
+    void toJdbcUrl_debeRetornarUrlValida() {
+        DBConfig config = new DBConfig("localhost", 3306, "estante_db", "admin", "1234");
+        String url = config.toJdbcUrl();
+        assertEquals("jdbc:mysql://localhost:3306/estante_db", url);
+    }
+
+    @Test
+    void constructor_debeLanzarExcepcion_cuandoPuertoEsCero() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new DBConfig("localhost", 0, "estante_db", "admin", "1234")
+        );
+    }
+
+    @Test
+    void constructor_debeLanzarExcepcion_cuandoCamposVacios() {
+        assertThrows(IllegalArgumentException.class, () ->
+            new DBConfig("", 3306, "estante_db", "admin", "1234")
+        );
+        assertThrows(IllegalArgumentException.class, () ->
+            new DBConfig("localhost", 3306, "", "admin", "1234")
+        );
+        assertThrows(IllegalArgumentException.class, () ->
+            new DBConfig("localhost", 3306, "estante_db", "", "1234")
+        );
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega DBConfigTest.java con 3 tests JUnit 5 que validan la URL JDBC, puerto inválido y campos vacíos. También agrega junit-jupiter y maven-surefire-plugin al pom.xml

## Issue relacionado
Closes #27

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/de7169e2-d4f2-446b-87ec-eddeb9656f7c" />