### PR TITLE
feat(core): definir excepciones tipadas del dominio #120

### DIFF
--- a/src/main/java/edu/sisinf/estante/core/ErrorConexion.java
+++ b/src/main/java/edu/sisinf/estante/core/ErrorConexion.java
@@ -1,0 +1,16 @@
+package edu.sisinf.estante.core;
+
+/**
+ * Excepcion lanzada cuando falla un intento de conexion a la base de datos.
+ * Ejemplos: credenciales invalidas, host inalcanzable, puerto incorrecto.
+ */
+public class ErrorConexion extends ErrorEstante {
+
+    public ErrorConexion(String message) {
+        super(message);
+    }
+
+    public ErrorConexion(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/edu/sisinf/estante/core/ErrorEstante.java
+++ b/src/main/java/edu/sisinf/estante/core/ErrorEstante.java
@@ -1,0 +1,16 @@
+package edu.sisinf.estante.core;
+
+/**
+ * Excepcion base para todos los errores de dominio en Estante.
+ * Todas las excepciones tipadas en la aplicacion deben extender de esta clase.
+ */
+public class ErrorEstante extends RuntimeException {
+
+    public ErrorEstante(String message) {
+        super(message);
+    }
+
+    public ErrorEstante(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/edu/sisinf/estante/core/ErrorPersistencia.java
+++ b/src/main/java/edu/sisinf/estante/core/ErrorPersistencia.java
@@ -1,0 +1,16 @@
+package edu.sisinf.estante.core;
+
+/**
+ * Excepcion lanzada cuando falla una operacion de persistencia de configuracion.
+ * Ejemplos: archivo no escribible, configuracion corrupta, error de E/S al guardar.
+ */
+public class ErrorPersistencia extends ErrorEstante {
+
+    public ErrorPersistencia(String message) {
+        super(message);
+    }
+
+    public ErrorPersistencia(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/edu/sisinf/estante/core/ErrorQuery.java
+++ b/src/main/java/edu/sisinf/estante/core/ErrorQuery.java
@@ -1,0 +1,16 @@
+package edu.sisinf.estante.core;
+
+/**
+ * Excepcion lanzada cuando una consulta SQL falla durante su ejecucion.
+ * Ejemplos: errores de sintaxis, tabla inexistente, privilegios insuficientes.
+ */
+public class ErrorQuery extends ErrorEstante {
+
+    public ErrorQuery(String message) {
+        super(message);
+    }
+
+    public ErrorQuery(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega las cuatro clases de excepción tipadas del dominio: `ErrorEstante` (base), `ErrorConexion`, `ErrorQuery` y `ErrorPersistencia`, ubicadas en `edu.sisinf.estante.core`.

## Issue relacionado
Closes #120

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/bcf72a76-e0f3-41b0-8b90-9ea5010b7239" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/fa801e86-a2c0-4d9f-a7e6-e30440e46edb" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/6d531fce-058c-452a-b5c7-c5de67c23715" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/d3dfe38a-a8f3-4995-8729-ca2dedfd4775" />

