### PR TITLE
chore: añadir plugin maven-jar-plugin con Main-Class - Closes #40

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,18 @@
                     <argLine>-Dnet.bytebuddy.experimental=true</argLine>
                 </configuration>
             </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-jar-plugin</artifactId>
+               <version>3.3.0</version>
+               <configuration>
+                  <archive>
+                     <manifest>
+                        <mainClass>edu.sisinf.estante.Main</mainClass>
+                     </manifest>
+                  </archive>
+                </configuration>
+         </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## ¿Qué hace este PR?
Configura el plugin maven-jar-plugin en el archivo pom.xml para generar un JAR ejecutable con Main-Class definida.

## Issue relacionado
Closes #40

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se agregó la configuración de maven-jar-plugin en pom.xml para generar un JAR ejecutable.