### PR TITLE
feat: añadir manejo de timeout en conexión - Closes #37

### DIFF
--- a/MySqlConnectionProvider.java
+++ b/MySqlConnectionProvider.java
@@ -7,26 +7,28 @@ public class MySqlConnectionProvider implements ConnectionProvider {
     private String url;
     private String user;
     private String password;
-
-    public MySqlConnectionProvider(String url, String user, String password) {
+    private int timeoutSeconds;
+    public MySqlConnectionProvider(String url, String user, String password, int timeoutSeconds) {
         this.url = url;
         this.user = user;
         this.password = password;
+        this.timeoutSeconds = timeoutSeconds;
     }
 
     @Override
     public Connection getConnection() {
         try {
+            DriverManager.setLoginTimeout(timeoutSeconds);
             return DriverManager.getConnection(url, user, password);
         } catch (SQLException e) {
             System.out.println("Error al conectar: " + e.getMessage());
-            return null;
+            throw new RuntimeException("Tiempo de conexión excedido");
         }
     }
 
     public static void main(String[] args) {
         MySqlConnectionProvider provider =
-            new MySqlConnectionProvider("jdbc:mysql://localhost:3306/test", "root", "1234");
+            new MySqlConnectionProvider("jdbc:mysql://localhost:3306/test", "root", "1234", 5);
 
         if (provider.getConnection() != null) {
             System.out.println("Conectado");


### PR DESCRIPTION
## ¿Qué hace este PR?
Se agregó configuración de timeout en conexiones JDBC usando DriverManager.setLoginTimeout y manejo de excepción por tiempo excedido.

## Issue relacionado
Closes #37

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se agregó configuración de timeout mediante DriverManager.setLoginTimeout(timeoutSeconds) y manejo de excepción por tiempo excedido en MySqlConnectionProvider.java.