### PR TITLE
fix(docs): corregir inconsistencia en estandares-codigo.md - Closes #96

### DIFF
--- a/docs/estandares-codigo.md
+++ b/docs/estandares-codigo.md
@@ -161,9 +161,13 @@ public class UserService {
 - 100 caracteres → límite por línea
 - Javadoc → documentación
 - Consistencia > preferencias personales
-- Código → Español
+- Código → Inglés
 
 > [!NOTE]
 > - Los ejemplos presentados son ilustrativos.
 > - No es necesario que el código sea exactamente igual,
 > - pero sí respetar las buenas prácticas descritas.
+
+## ✅ Conclusión
+
+El proyecto utilizará nombres en inglés para clases, métodos, variables y funciones con el objetivo de mantener consistencia con las buenas prácticas de desarrollo en Java y facilitar la comprensión del código.


### PR DESCRIPTION
Se corrigió la inconsistencia del idioma usado en ejemplos y conclusión del documento de estándares.

## ¿Qué hace este PR?
Se corrigió la inconsistencia entre el idioma usado en ejemplos y la conclusión del documento de estándares de código.

## Issue relacionado
Closes #96

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [ ] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Documento actualizado corrigiendo el idioma usado en ejemplos y conclusión.