### PR TITLE
chore: agregar editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,22 +1,15 @@
 root = true
 
 [*]
-charset = utf-8
+indent_style = space
+indent_size = 4
 end_of_line = lf
-insert_final_newline = true
+charset = utf-8
 trim_trailing_whitespace = true
+insert_final_newline = true
 
-[*.java]
-indent_style = space
-indent_size = 4
-charset = utf-8
+[*.{xml,fxml}]
+indent_size = 2
 
-[*.sql]
-indent_style = space
-indent_size = 4
-charset = utf-8
-
-[*.xml]
-indent_style = space
-indent_size = 4
-charset = utf-8
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el archivo `.editorconfig` en la raíz del proyecto para unificar el formato del código entre los colaboradores.

Incluye reglas para espacios, codificación UTF-8, saltos de línea LF, limpieza de espacios finales y una configuración específica para archivos XML/FXML y Markdown.

## Issue relacionado
Closes #114 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas