### PR TITLE
feat: definir interfaz de repositorio de conexiones

### DIFF
--- a/src/main/java/edu/sisinf/estante/dao/IRepositorioConexiones.java
+++ b/src/main/java/edu/sisinf/estante/dao/IRepositorioConexiones.java
@@ -1,0 +1,50 @@
+package edu.sisinf.estante.dao;
+
+import edu.sisinf.estante.core.ErrorPersistencia;
+import edu.sisinf.estante.modelo.Conexion;
+import java.util.List;
+import java.util.Optional;
+
+public interface IRepositorioConexiones {
+
+    /**
+     * Devuelve todas las conexiones guardadas.
+     *
+     * @return lista de conexiones guardadas; si no existen conexiones, devuelve una lista vacía.
+     */
+    List<Conexion> listar();
+
+    /**
+     * Busca una conexión por su identificador.
+     *
+     * @param id identificador de la conexión a buscar.
+     * @return Optional con la conexión si existe; Optional vacío si no existe.
+     */
+    Optional<Conexion> buscarPorId(String id);
+
+    /**
+     * Persiste una conexión nueva.
+     * Si la conexión recibida no tiene id, la implementación debe asignarle uno antes de guardarla.
+     *
+     * @param conexion conexión a guardar.
+     * @return conexión persistida con id asignado.
+     * @throws ErrorPersistencia si ocurre un error durante la persistencia.
+     */
+    Conexion guardar(Conexion conexion) throws ErrorPersistencia;
+
+    /**
+     * Actualiza una conexión existente identificándola por su id.
+     *
+     * @param conexion conexión a actualizar.
+     * @throws ErrorPersistencia si no existe una conexión con el id indicado o si ocurre un error de persistencia.
+     */
+    void actualizar(Conexion conexion) throws ErrorPersistencia;
+
+    /**
+     * Elimina la conexión con el id indicado.
+     *
+     * @param id identificador de la conexión a eliminar.
+     * @throws ErrorPersistencia si no existe una conexión con el id indicado o si ocurre un error de persistencia.
+     */
+    void eliminar(String id) throws ErrorPersistencia;
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega la interfaz `IRepositorioConexiones` dentro del paquete `edu.sisinf.estante.dao`.

Esta interfaz define las operaciones básicas para gestionar conexiones guardadas: listar, buscar por id, guardar, actualizar y eliminar. También incluye Javadoc en cada método, indicando su comportamiento y las excepciones correspondientes.

## Issue relacionado
Closes #121 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas