### PR TITLE
feat(core): crear clase QueryTimer.java para medir tiempo de ejecución de queries - Closes#179

### DIFF
--- a/src/main/java/edu/sisinf/estante/core/QueryTimer.java
+++ b/src/main/java/edu/sisinf/estante/core/QueryTimer.java
@@ -1,0 +1,5 @@
+package edu.sisinf.estante.core;
+
+public class QueryTimer {
+    
+}

--- a/src/main/java/edu/sisinf/estante/core/QueryTimer.java
+++ b/src/main/java/edu/sisinf/estante/core/QueryTimer.java
@@ -1,5 +1,56 @@
 package edu.sisinf.estante.core;
 
+/**
+ * Clase utilitaria para medir el tiempo de ejecución de queries.
+ * Utiliza System.nanoTime() para mayor precisión.
+ */
 public class QueryTimer {
-    
+
+    private Long tiempoInicio;
+    private Long tiempoFin;
+
+    /**
+     * Registra el tiempo de inicio de la medición.
+     */
+    public void iniciar() {
+        tiempoInicio = System.nanoTime();
+        tiempoFin = null;
+    }
+
+    /**
+     * Registra el tiempo de fin de la medición.
+     */
+    public void detener() {
+        tiempoFin = System.nanoTime();
+    }
+
+    /**
+     * Devuelve la diferencia entre inicio y fin en milisegundos.
+     *
+     * @return tiempo transcurrido en milisegundos
+     * @throws IllegalStateException si se llama antes de invocar detener()
+     */
+    public double getTiempoMs() {
+        if (tiempoFin == null) {
+            throw new IllegalStateException(
+                "No se puede obtener el tiempo: detener() no ha sido llamado.");
+        }
+        return (tiempoFin - tiempoInicio) / 1_000_000.0;
+    }
+
+    /**
+     * Devuelve el tiempo formateado como string.
+     * Ejemplos: "123 ms", "1.2 s"
+     *
+     * @return string con el tiempo formateado
+     * @throws IllegalStateException si se llama antes de invocar detener()
+     */
+    public String getTiempoFormateado() {
+        double ms = getTiempoMs();
+        if (ms < 1000) {
+            return String.format("%.0f ms", ms);
+        } else {
+            return String.format("%.1f s", ms / 1000.0);
+        }
+    }
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega la clase `QueryTimer.java` en el paquete `edu.sisinf.estante.core` para encapsular la medición de tiempo de ejecución de queries mediante `System.nanoTime()`.
La clase expone un ciclo de uso simple: `iniciar()` antes del query, `detener()` al finalizar, y `getTiempoMs()` o `getTiempoFormateado()` para consultar el resultado. El método `getTiempoFormateado()` devuelve el tiempo como `"123 ms"` para valores menores a 1000 ms, o `"1.2 s"` para valores mayores. Llamar `getTiempoMs()` sin haber invocado `detener()` lanza una `IllegalStateException`.
Este PR agrega únicamente el archivo `src/main/java/edu/sisinf/estante/core/QueryTimer.java` sin modificar ningún archivo existente.

## Issue relacionado
Closes #179

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde