### PR TITLE
feat(modelo): crear clase ResultadoQuery.java con filas y columnas de un SELECT - Closes#176

### DIFF
--- a/src/main/java/edu/sisinf/estante/modelo/ResultadoQuery.java
+++ b/src/main/java/edu/sisinf/estante/modelo/ResultadoQuery.java
@@ -79,6 +79,11 @@ public class ResultadoQuery {
         totalFilas++;
     }
     
+    //Devuelve true si no hay filas en el resultado
+    public boolean estaVacio() {
+        return filas.isEmpty();
+    }
+
     public Tipo getTipo() {
         return tipo;
     }

--- a/src/main/java/edu/sisinf/estante/modelo/ResultadoQuery.java
+++ b/src/main/java/edu/sisinf/estante/modelo/ResultadoQuery.java
@@ -24,6 +24,13 @@ public class ResultadoQuery {
         this.filasAfectadas = 0;
     }
 
+    // Constructor que recibe columnas para consultas SELECT
+    public ResultadoQuery(List<String> columnas) {
+        this();
+        this.tipo = Tipo.LECTURA;
+        this.columnas = new ArrayList<>(columnas);
+    }
+
     public static ResultadoQuery deLectura(
             List<String> columnas,
             List<List<Object>> filas,

--- a/src/main/java/edu/sisinf/estante/modelo/ResultadoQuery.java
+++ b/src/main/java/edu/sisinf/estante/modelo/ResultadoQuery.java
@@ -17,6 +17,7 @@ public class ResultadoQuery {
     private int filasAfectadas;
     private long tiempoMs;
     private String mensaje;
+    private int totalFilas;
 
     private ResultadoQuery() {
         this.columnas = new ArrayList<>();
@@ -66,6 +67,18 @@ public class ResultadoQuery {
         return resultado;
     }
 
+    //Lanza IllegalArgumentException si el tamaño no coincide con columnas
+    public void agregarFila(List<Object> fila) {
+        if (fila == null || fila.size() != columnas.size()) {
+            throw new IllegalArgumentException(
+                "El tamaño de la fila (" + (fila == null ? "null" : fila.size()) +
+                ") no coincide con el número de columnas (" + columnas.size() + ")."
+            );
+        }
+        filas.add(new ArrayList<>(fila));
+        totalFilas++;
+    }
+    
     public Tipo getTipo() {
         return tipo;
     }
@@ -80,6 +93,10 @@ public class ResultadoQuery {
 
     public int getFilasAfectadas() {
         return filasAfectadas;
+    }
+
+    public int getTotalFilas() {
+        return totalFilas;
     }
 
     public long getTiempoMs() {


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega la clase `ResultadoQuery.java` en el paquete `edu.sisinf.estante.modelo` como contenedor de datos para los resultados de consultas SELECT ejecutadas en la aplicación.

Se agregó a ResultadoQuery.java, ya existente, lo siguiente:

- Constructor público `ResultadoQuery(List<String> columnas)` para instanciar resultados de lectura.
- Método `agregarFila(List<Object> fila)` que lanza `IllegalArgumentException` si el tamaño de la fila no coincide con el número de columnas.
- Método `estaVacio()` que devuelve `true` cuando no se han agregado filas.
- Campo `totalFilas` consistente con el número de filas agregadas, accesible mediante `getTotalFilas()`.

## Issue relacionado
Closes #176

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Captura de compilación del archivo ResultadoQuery.java mediante el comando `javac src/main/java/edu/sisinf/estante/modelo/ResultadoQuery.java`:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f56d77fd-283b-4943-becc-01cef8218133" />
