### PR TITLE
feat(modelo): crear clase Conexion.java con datos de una conexión MySQL

### DIFF
--- a/src/main/java/edu/sisinf/estante/modelo/Conexion.java
+++ b/src/main/java/edu/sisinf/estante/modelo/Conexion.java
@@ -1,68 +1,83 @@
+// ============================================================
+// ARCHIVO: Conexion.java
+// RUTA: src/main/java/edu/sisinf/estante/modelo/Conexion.java
+// ============================================================
 package edu.sisinf.estante.modelo;
 
+/**
+ * Representa los datos de conexion necesarios para establecer una sesion de base de datos MySQL.
+ * Se trata de un objeto Java simple (POJO) sin dependencias externas.
+ */
 public class Conexion {
-    private String id;            // identificador único, ej. UUID
-    private String nombre;        // nombre legible para el usuario
-    private TipoMotor tipoMotor;  // SQLITE o MYSQL
-    private String host;          // null para SQLite
-    private Integer puerto;       // null para SQLite
-    private String basedatos;     // ruta del archivo para SQLite, nombre de BD para MySQL
-    private String usuario;       // null o vacío para SQLite
-    private String password;      // null o vacío para SQLite
+    private String id;            
+    private String nombre;        
+    private String host;          
+    private int puerto;       
+    private String baseDatos;     
+    private String usuario;      
+    private String contrasena;      
 
-    // Constructor sin argumentos requerido por Jackson
-    public Conexion() {}
+    /** Constructor sin argumentos. Establece el puerto predeterminado en 3306. */
 
-    // Constructor con todos los campos
-    public Conexion(String id, String nombre, TipoMotor tipoMotor,
-                    String host, Integer puerto, String basedatos,
-                    String usuario, String password) {
-        this.id = id;
-        this.nombre = nombre;
-        this.tipoMotor = tipoMotor;
+    public Conexion() {
+        this.puerto = 3306;
+    }
+
+    /**
+    * Constructor completo (excluye el ID, que se asigna externamente).
+    *
+    * @param nombre Etiqueta legible para esta conexion
+    * @param host Nombre de host o direccion IP del servidor
+    * @param puerto Puerto TCP (normalmente 3306)
+    * @param usuario Nombre de usuario de MySQL
+    * @param contrasena Contraseña de MySQL
+    * @param baseDatos Nombre de la base de datos de destino
+    */
+    public Conexion(String nombre,String host, int puerto,
+                    String baseDatos,String usuario, String contrasena) {
+        this.nombre = nombre; 
         this.host = host;
         this.puerto = puerto;
-        this.basedatos = basedatos;
+        this.baseDatos = baseDatos;
         this.usuario = usuario;
-        this.password = password;
+        this.contrasena = contrasena;
     }
 
     // Getters y Setters
+
     public String getId() { return id; }
     public void setId(String id) { this.id = id; }
 
     public String getNombre() { return nombre; }
     public void setNombre(String nombre) { this.nombre = nombre; }
 
-    public TipoMotor getTipoMotor() { return tipoMotor; }
-    public void setTipoMotor(TipoMotor tipoMotor) { this.tipoMotor = tipoMotor; }
-
     public String getHost() { return host; }
     public void setHost(String host) { this.host = host; }
 
-    public Integer getPuerto() { return puerto; }
-    public void setPuerto(Integer puerto) { this.puerto = puerto; }
+    public int getPuerto() { return puerto; }
+    public void setPuerto(int puerto) { this.puerto = puerto; }
 
-    public String getBasedatos() { return basedatos; }
-    public void setBasedatos(String basedatos) { this.basedatos = basedatos; }
+    public String getBaseDatos() { return baseDatos; }
+    public void setBaseDatos(String baseDatos) { this.baseDatos = baseDatos; }
 
     public String getUsuario() { return usuario; }
     public void setUsuario(String usuario) { this.usuario = usuario; }
 
-    public String getPassword() { return password; }
-    public void setPassword(String password) { this.password = password; }
+    public String getContrasena() { return contrasena; }
+    public void setContrasena(String contrasena) { this.contrasena = contrasena; }
 
-    // toString() sin password
+    // --------------------------------------------------------
+    // Sobrescrituras de objetos
+    // --------------------------------------------------------
+    /**
+
+    * Devuelve una representacion segura en cadena de esta conexion.
+    * La contraseña se omite intencionalmente para evitar su exposicion accidental en los registros.
+    *
+    * @return cadena formateada: nombre@host:puerto/baseDatos
+    */
     @Override
     public String toString() {
-        return "Conexion{" +
-                "id='" + id + '\'' +
-                ", nombre='" + nombre + '\'' +
-                ", tipoMotor=" + tipoMotor +
-                ", host='" + host + '\'' +
-                ", puerto=" + puerto +
-                ", basedatos='" + basedatos + '\'' +
-                ", usuario='" + usuario + '\'' +
-                '}';
+        return nombre + "@" + host + ":" + puerto + "/" + baseDatos;
     }
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea la clase `Conexion.java` en `edu.sisinf.estante.modelo` como POJO puro con los 7 campos requeridos, dos constructores, getters/setters y un `toString()` que no expone la contraseña.

## Issue relacionado
Closes #174 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/f0d1259d-bcb1-42d0-8a85-bc10cd35b483" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/068848d7-605c-4ffa-b08f-200cbf8c83d8" />
