### PR TITLE
feat(servicio): implementar EjecutorQuery

### DIFF
--- a/src/main/java/edu/sisinf/estante/servicio/EjecutorQuery.java
+++ b/src/main/java/edu/sisinf/estante/servicio/EjecutorQuery.java
@@ -1,0 +1,85 @@
+package edu.sisinf.estante.servicio;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+// Importaciones basadas en los issues bloqueantes #115 y #118
+import edu.sisinf.estante.modelo.ResultadoQuery;
+import edu.sisinf.estante.util.SqlValidator;
+
+/**
+ * Servicio centralizado para la ejecución de consultas SQL.
+ */
+public class EjecutorQuery {
+
+    /**
+     * Ejecuta una consulta SQL en la conexión proporcionada sin alterar el ciclo de vida de la conexión.
+     *
+     * @param conexion Conexión activa a la base de datos (responsabilidad del consumidor).
+     * @param sql      Cadena SQL a ejecutar.
+     * @return ResultadoQuery con los datos obtenidos, conteo de filas afectadas o mensaje de error.
+     */
+    public ResultadoQuery ejecutar(Connection conexion, String sql) {
+        // 1. Medición de tiempo: Registrar el inicio
+        long tiempoInicio = System.currentTimeMillis();
+
+        try {
+            // 2. Clasificación: Determinar el tipo de query
+            // (Si SqlValidator devuelve un Enum, asegúrate de usar .name() o .toString() según corresponda)
+            String tipoQuery = SqlValidator.tipo(sql).toString();
+
+            // 3. Ramificación según el tipo
+            if ("SELECT".equalsIgnoreCase(tipoQuery)) {
+                
+                // --- Ejecución como lectura ---
+                // Uso de try-with-resources para garantizar el cierre
+                try (Statement stmt = conexion.createStatement();
+                     ResultSet rs = stmt.executeQuery(sql)) {
+
+                    ResultSetMetaData metaData = rs.getMetaData();
+                    int numColumnas = metaData.getColumnCount();
+
+                    // Extraer los nombres de columnas (índice 1-based)
+                    List<String> columnas = new ArrayList<>();
+                    for (int i = 1; i <= numColumnas; i++) {
+                        columnas.add(metaData.getColumnLabel(i));
+                    }
+
+                    // Iterar sobre las filas y construir la lista
+                    List<List<Object>> filas = new ArrayList<>();
+                    while (rs.next()) {
+                        List<Object> fila = new ArrayList<>();
+                        for (int i = 1; i <= numColumnas; i++) {
+                            fila.add(rs.getObject(i));
+                        }
+                        filas.add(fila);
+                    }
+
+                    long tiempoMs = System.currentTimeMillis() - tiempoInicio;
+                    return ResultadoQuery.deLectura(columnas, filas, tiempoMs);
+                }
+
+            } else {
+                
+                // --- Ejecución como escritura (DML, DDL, DESCONOCIDO) ---
+                // Uso de try-with-resources solo para el Statement
+                try (Statement stmt = conexion.createStatement()) {
+                    int filasAfectadas = stmt.executeUpdate(sql);
+                    
+                    long tiempoMs = System.currentTimeMillis() - tiempoInicio;
+                    return ResultadoQuery.deEscritura(filasAfectadas, tiempoMs);
+                }
+            }
+
+        } catch (SQLException e) {
+            // 4. Manejo de errores: Capturar y traducir sin propagar al consumidor
+            long tiempoMs = System.currentTimeMillis() - tiempoInicio;
+            return ResultadoQuery.deError(e.getMessage(), tiempoMs);
+        }
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el servicio `EjecutorQuery` encargado de la ejecución de consultas SQL. El servicio clasifica automáticamente las consultas en **Lectura** (SELECT) o **Escritura** (DML, DDL), gestiona los metadatos de los resultados, mide el tiempo de ejecución en milisegundos y maneja excepciones `SQLException` sin propagarlas al consumidor.

## Issue relacionado
Closes #122

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
* **Código implementado:** Se creó el archivo `src/main/java/edu/sisinf/estante/servicio/EjecutorQuery.java` siguiendo los criterios de aceptación.
<img width="637" height="181" alt="image" src="https://github.com/user-attachments/assets/ac8c4c3a-66fc-440c-8af3-d450694fcf5a" />
<img width="1315" height="672" alt="image" src="https://github.com/user-attachments/assets/3c49be25-decb-4a6f-b900-9b3098072357" />
<img width="704" height="356" alt="image" src="https://github.com/user-attachments/assets/3db1cdd1-ff08-456c-8e14-33c84457f3f9" />

* **Nota sobre compilación:** Al intentar verificar el criterio de aceptación mediante `mvn clean compile`, se detectó un error de sintaxis previo en el archivo `HistorialConsultas.java` (caracteres ilegales ` ``` `) que impide el BUILD SUCCESS general del proyecto. Mi código ha sido validado para cumplir con la lógica de JDBC y el uso de `try-with-resources` solicitado, quedando a la espera de la corrección del archivo mencionado para el éxito de la compilación global.
<img width="1366" height="728" alt="image" src="https://github.com/user-attachments/assets/df46c3b4-f178-46b5-9932-be41c2cdcbee" />
