### PR TITLE
feat: añadir método executeUpdate() para INSERT/UPDATE 

### DIFF
--- a/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
+++ b/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
@@ -4,6 +4,8 @@ import edu.sisinf.estante.config.DBConfig;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import edu.sisinf.estante.util.SqlValidator;
+import java.sql.Statement;
 
 /**
  * Proveedor de conexiones JDBC.
@@ -29,5 +31,31 @@ public class ConnectionProvider {
                 config.getUsuario(),
                 config.getPassword()
         );
+    }
+    /**
+ * Ejecuta una sentencia de escritura (INSERT, UPDATE, DELETE) y retorna
+ * el número de filas afectadas.
+ *
+ * <p>Este método rechaza explícitamente sentencias SELECT, ya que está
+ * diseñado exclusivamente para operaciones de modificación de datos.</p>
+ *
+ * @param connection conexión JDBC activa sobre la que se ejecuta la sentencia
+ * @param sql        sentencia SQL de escritura (INSERT, UPDATE o DELETE)
+ * @return número de filas afectadas por la sentencia
+ * @throws IllegalArgumentException si la sentencia es un SELECT
+ * @throws ErrorQuery               si ocurre un error durante la ejecución SQL
+ */
+public static int executeUpdate(Connection connection, String sql) {
+    if (SqlValidator.esLectura(sql)) {
+        throw new IllegalArgumentException(
+                "executeUpdate() no acepta sentencias SELECT. Use executeQuery() para lecturas."
+        );
+    }
+
+    try (Statement statement = connection.createStatement()) {
+        return statement.executeUpdate(sql);
+    } catch (SQLException e) {
+        throw new ErrorQuery("Error al ejecutar la sentencia de escritura: " + e.getMessage(), e);
+        }
     }
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el método `executeUpdate()` en `ConnectionProvider.java` para ejecutar sentencias de escritura (INSERT o UPDATE) y retornar el número de filas afectadas. Rechaza explícitamente sentencias SELECT y maneja `SQLException` envolviéndola en `ErrorQuery`.

## Issue relacionado
Closes #32 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/54d9b575-f9ed-493f-b6ac-b22fc6587c64" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/5e533f30-4973-4227-b14e-1ccf375b07b3" />
