### PR TITLE
feat: crear método executeSelect() en ConnectionProvider

### DIFF
--- a/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
+++ b/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
@@ -4,6 +4,12 @@ import edu.sisinf.estante.config.DBConfig;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import edu.sisinf.estante.dto.QueryResult;
+import edu.sisinf.estante.util.SqlValidator;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Proveedor de conexiones JDBC.
@@ -30,4 +36,60 @@ public class ConnectionProvider {
                 config.getPassword()
         );
     }
+    /**
+ * Ejecuta una sentencia SELECT y retorna el resultado encapsulado en un {@link QueryResult}.
+ *
+ * <p>Los recursos ({@link Statement} y {@link ResultSet}) se cierran en el bloque
+ * {@code finally} para garantizar su liberación incluso si ocurre un error.</p>
+ *
+ * @param connection conexión JDBC activa sobre la que se ejecuta la consulta
+ * @param sql        sentencia SQL de lectura (debe ser SELECT)
+ * @return {@link QueryResult} con las columnas y filas del resultado
+ * @throws IllegalArgumentException si la sentencia no es un SELECT
+ * @throws ErrorQuery               si ocurre un error durante la ejecución SQL
+ */
+public static QueryResult executeSelect(Connection connection, String sql) {
+    if (!SqlValidator.esLectura(sql)) {
+        throw new IllegalArgumentException(
+                "executeSelect() solo acepta sentencias SELECT. Use executeUpdate() para escrituras."
+        );
+    }
+
+    Statement statement = null;
+    ResultSet resultSet = null;
+
+    try {
+        statement = connection.createStatement();
+        resultSet = statement.executeQuery(sql);
+
+        ResultSetMetaData metadata = resultSet.getMetaData();
+        int columnCount = metadata.getColumnCount();
+
+        List<String> columns = new ArrayList<>();
+        for (int i = 1; i <= columnCount; i++) {
+            columns.add(metadata.getColumnName(i));
+        }
+
+        List<List<Object>> rows = new ArrayList<>();
+        while (resultSet.next()) {
+            List<Object> row = new ArrayList<>();
+            for (int i = 1; i <= columnCount; i++) {
+                row.add(resultSet.getObject(i));
+            }
+            rows.add(row);
+        }
+
+        return QueryResult.of(columns, rows);
+
+    } catch (SQLException e) {
+        throw new ErrorQuery("Error al ejecutar la sentencia SELECT: " + e.getMessage(), e);
+    } finally {
+        if (resultSet != null) {
+            try { resultSet.close(); } catch (SQLException ignored) {}
+        }
+        if (statement != null) {
+            try { statement.close(); } catch (SQLException ignored) {}
+        }
+    }
+}
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el método `executeSelect()` en `ConnectionProvider.java` para ejecutar sentencias SELECT y retornar el resultado encapsulado en un `QueryResult`. Usa `Statement` y `ResultSet`, cierra ambos recursos en el bloque `finally` y lanza `IllegalArgumentException` si la sentencia no es un SELECT.

## Issue relacionado
Closes #29 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/6c131dd0-f7ba-4203-b1ad-90c4c656ecb9" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/8b63155d-2e3a-4fe8-9b77-2a519f825dff" />
