### PR TITLE
feat(config): implementar ConfiguracionApp con paths de la aplicación

### DIFF
--- a/src/main/java/edu/sisinf/estante/config/ConfiguracionApp.java
+++ b/src/main/java/edu/sisinf/estante/config/ConfiguracionApp.java
@@ -1,0 +1,69 @@
+// ============================================================
+// ARCHIVO: ConfiguracionApp.java
+// RUTA: src/main/java/edu/sisinf/estante/config/ConfiguracionApp.java
+// ============================================================
+package edu.sisinf.estante.config;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Centraliza los paths de la aplicacion Estante.
+ *
+ * <p>Todos los metodos son estaticos. Esta clase no puede ser instanciada.</p>
+ *
+ * <p>La aplicacion almacena sus archivos en un directorio oculto dentro del
+ * home del usuario:</p>
+ * <ul>
+ *   <li>Linux / macOS: {@code ~/.estante/}</li>
+ *   <li>Windows: {@code C:\Users\<usuario>\.estante\}</li>
+ * </ul>
+ */
+public class ConfiguracionApp {
+
+    /** Nombre del directorio oculto que usa la aplicacion dentro del home del usuario. */
+    private static final String APP_DIRECTORY = ".estante";
+
+    /** Nombre del archivo que almacena las conexiones del usuario. */
+    private static final String CONNECTIONS_FILE = "conexiones.json";
+
+    /** Constructor privado para evitar instanciacion. */
+    private ConfiguracionApp() {}
+
+    /**
+     * Devuelve el path del directorio home de la aplicacion.
+     *
+     * <p>El directorio se construye combinando la propiedad del sistema
+     * {@code user.home} con el subdirectorio {@value #APP_DIRECTORY}.</p>
+     *
+     * @return {@link Path} que apunta a {@code <user.home>/.estante/}
+     */
+    public static Path directorioHome() {
+        return Paths.get(System.getProperty("user.home"), APP_DIRECTORY);
+    }
+
+    /**
+     * Devuelve el archivo de conexiones de la aplicacion.
+     *
+     * <p>El archivo se ubica dentro del directorio home de la aplicacion
+     * con el nombre {@value #CONNECTIONS_FILE}.</p>
+     *
+     * @return {@link File} que apunta a {@code <user.home>/.estante/conexiones.json}
+     */
+    public static File archivoConexiones() {
+        return directorioHome().resolve(CONNECTIONS_FILE).toFile();
+    }
+
+    /**
+     * Crea el directorio home de la aplicacion si no existe.
+     *
+     * <p>Este metodo es idempotente: llamarlo múltiples veces no produce error
+     * ni efectos secundarios si el directorio ya existe.</p>
+     *
+     * <p>Solo crea el directorio; no crea ningun archivo dentro de el.</p>
+     */
+    public static void asegurarDirectorioHome() {
+        directorioHome().toFile().mkdirs();
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea la clase `ConfiguracionApp.java` en `edu.sisinf.estante.config` que centraliza los paths de la aplicación. Expone tres métodos estáticos: `directorioHome()` que retorna el path a `<user.home>/.estante/`, `archivoConexiones()` que retorna el archivo `conexiones.json` dentro de ese directorio, y `asegurarDirectorioHome()` que crea el directorio si no existe de forma idempotente.


## Issue relacionado
Closes #128 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/667976eb-8567-4b0a-8484-29b48305cd45" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/e22344aa-e582-4b4c-a99b-0a5c5dff3b83" />
