### PR TITLE
feat: crear ventana principal base en FXML

### DIFF
--- a/src/main/java/edu/sisinf/estante/controller/VentanaPrincipalController.java
+++ b/src/main/java/edu/sisinf/estante/controller/VentanaPrincipalController.java
@@ -1,0 +1,66 @@
+package edu.sisinf.estante.controller;
+
+import javafx.application.Platform;
+import javafx.fxml.FXML;
+import javafx.scene.control.MenuItem;
+import javafx.scene.layout.StackPane;
+
+/**
+ * Controller principal de la ventana base de Estante.
+ */
+public class VentanaPrincipalController {
+
+    @FXML
+    private MenuItem menuNuevaConexion;
+
+    @FXML
+    private MenuItem menuSalir;
+
+    @FXML
+    private MenuItem menuAcercaDe;
+
+    @FXML
+    private StackPane contenedorArbol;
+
+    @FXML
+    private StackPane contenedorEditor;
+
+    @FXML
+    private StackPane contenedorResultado;
+
+    @FXML
+    private StackPane contenedorBarraEstado;
+
+    @FXML
+    public void initialize() {
+        menuSalir.setOnAction(event -> Platform.exit());
+    }
+
+    public MenuItem getMenuNuevaConexion() {
+        return menuNuevaConexion;
+    }
+
+    public MenuItem getMenuSalir() {
+        return menuSalir;
+    }
+
+    public MenuItem getMenuAcercaDe() {
+        return menuAcercaDe;
+    }
+
+    public StackPane getContenedorArbol() {
+        return contenedorArbol;
+    }
+
+    public StackPane getContenedorEditor() {
+        return contenedorEditor;
+    }
+
+    public StackPane getContenedorResultado() {
+        return contenedorResultado;
+    }
+
+    public StackPane getContenedorBarraEstado() {
+        return contenedorBarraEstado;
+    }
+}

--- a/src/main/resources/css/estante.css
+++ b/src/main/resources/css/estante.css
@@ -1,0 +1,4 @@
+.root {
+    -fx-font-family: "Arial";
+    -fx-font-size: 14px;
+}

--- a/src/main/resources/fxml/VentanaPrincipal.fxml
+++ b/src/main/resources/fxml/VentanaPrincipal.fxml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Menu?>
+<?import javafx.scene.control.MenuBar?>
+<?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.control.SplitPane?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.StackPane?>
+
+<BorderPane xmlns:fx="http://javafx.com/fxml"
+            fx:controller="edu.sisinf.estante.controller.VentanaPrincipalController"
+            prefWidth="1100.0"
+            prefHeight="700.0">
+
+    <top>
+        <MenuBar>
+            <menus>
+                <Menu text="Archivo">
+                    <items>
+                        <MenuItem fx:id="menuNuevaConexion" text="Nueva conexión..." />
+                        <MenuItem fx:id="menuSalir" text="Salir" />
+                    </items>
+                </Menu>
+
+                <Menu text="Ayuda">
+                    <items>
+                        <MenuItem fx:id="menuAcercaDe" text="Acerca de..." />
+                    </items>
+                </Menu>
+            </menus>
+        </MenuBar>
+    </top>
+
+    <center>
+        <SplitPane dividerPositions="0.25">
+
+            <StackPane fx:id="contenedorArbol" />
+
+            <SplitPane orientation="VERTICAL" dividerPositions="0.6">
+
+                <StackPane fx:id="contenedorEditor" />
+
+                <StackPane fx:id="contenedorResultado" />
+
+            </SplitPane>
+
+        </SplitPane>
+    </center>
+
+    <bottom>
+        <StackPane fx:id="contenedorBarraEstado" />
+    </bottom>
+
+</BorderPane>


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea la estructura base de la ventana principal usando JavaFX FXML.
Incluye:
- MenuBar principal
- SplitPane horizontal y vertical
- Contenedores StackPane para árbol, editor, resultados y barra de estado
- Controller con referencias @FXML
- CSS base para la aplicación

## Issue relacionado
Closes # 129

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se creó correctamente el layout base en FXML.