### PR TITLE
feat(util): crear clase ValidadorSQL.java para detectar tipo de sentencia SQL 

### DIFF
--- a/src/main/java/edu/sisinf/estante/util/ValidadorSQL.java
+++ b/src/main/java/edu/sisinf/estante/util/ValidadorSQL.java
@@ -1,0 +1,94 @@
+// ============================================================
+// ARCHIVO: ValidadorSQL.java
+// RUTA: src/main/java/edu/sisinf/estante/util/ValidadorSQL.java
+// ============================================================
+package edu.sisinf.estante.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * Utilidad estática para detectar el tipo de sentencia SQL ingresada por el usuario.
+ *
+ * <p>Todos los métodos ignoran mayúsculas/minúsculas y espacios iniciales.
+ * La detección se realiza mediante expresiones regulares sobre la biblioteca estándar,
+ * sin dependencias externas.</p>
+ *
+ * <p>Uso típico:</p>
+ * <pre>
+ *   ValidadorSQL.isSelect("SELECT * FROM usuarios"); // true
+ *   ValidadorSQL.isDML("delete from t");             // true
+ *   ValidadorSQL.esSentenciaValida(null);            // false
+ * </pre>
+ */
+public class ValidadorSQL {
+
+    private static final Pattern PATTERN_SELECT = Pattern.compile("^\\s*SELECT\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    private static final Pattern PATTERN_INSERT = Pattern.compile("^\\s*INSERT\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    private static final Pattern PATTERN_UPDATE = Pattern.compile("^\\s*UPDATE\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    private static final Pattern PATTERN_DELETE = Pattern.compile("^\\s*DELETE\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    /** Constructor privado para evitar instanciación. */
+    private ValidadorSQL() {}
+
+    /**
+     * Indica si la sentencia SQL es un SELECT.
+     *
+     * @param sql sentencia SQL a evaluar
+     * @return {@code true} si la sentencia comienza con SELECT
+     */
+    public static boolean isSelect(String sql) {
+        return esSentenciaValida(sql) && PATTERN_SELECT.matcher(sql).matches();
+    }
+
+    /**
+     * Indica si la sentencia SQL es un INSERT.
+     *
+     * @param sql sentencia SQL a evaluar
+     * @return {@code true} si la sentencia comienza con INSERT
+     */
+    public static boolean isInsert(String sql) {
+        return esSentenciaValida(sql) && PATTERN_INSERT.matcher(sql).matches();
+    }
+
+    /**
+     * Indica si la sentencia SQL es un UPDATE.
+     *
+     * @param sql sentencia SQL a evaluar
+     * @return {@code true} si la sentencia comienza con UPDATE
+     */
+    public static boolean isUpdate(String sql) {
+        return esSentenciaValida(sql) && PATTERN_UPDATE.matcher(sql).matches();
+    }
+
+    /**
+     * Indica si la sentencia SQL es un DELETE.
+     *
+     * @param sql sentencia SQL a evaluar
+     * @return {@code true} si la sentencia comienza con DELETE
+     */
+    public static boolean isDelete(String sql) {
+        return esSentenciaValida(sql) && PATTERN_DELETE.matcher(sql).matches();
+    }
+
+    /**
+     * Indica si la sentencia SQL es una operación DML de escritura (INSERT, UPDATE o DELETE).
+     *
+     * <p>Útil para mostrar advertencias antes de ejecutar operaciones destructivas.</p>
+     *
+     * @param sql sentencia SQL a evaluar
+     * @return {@code true} si la sentencia es INSERT, UPDATE o DELETE
+     */
+    public static boolean isDML(String sql) {
+        return isInsert(sql) || isUpdate(sql) || isDelete(sql);
+    }
+
+    /**
+     * Indica si la sentencia SQL es válida (no nula y no vacía).
+     *
+     * @param sql sentencia SQL a evaluar
+     * @return {@code false} si la sentencia es {@code null} o está vacía tras eliminar espacios
+     */
+    public static boolean esSentenciaValida(String sql) {
+        return sql != null && !sql.strip().isEmpty();
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea la clase `ValidadorSQL.java` en `edu.sisinf.estante.util` para detectar el tipo de sentencia SQL ingresada por el usuario mediante expresiones regulares.
Expone métodos estáticos `isSelect()`, `isInsert()`, `isUpdate()`, `isDelete()`, `isDML()` y `esSentenciaValida()`. Todos ignoran mayúsculas/minúsculas y espacios iniciales. Usa únicamente la biblioteca estándar de Java.

## Issue relacionado
Closes #178  

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="810" height="107" alt="image" src="https://github.com/user-attachments/assets/93ee66d8-ecb2-4d90-8850-ea2add3cb431" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/462749d9-4e85-41ba-b103-28f93801fbc3" />
<img width="1362" height="766" alt="image" src="https://github.com/user-attachments/assets/7e838635-2556-4caa-811c-76e9dccdd6f4" />
