### PR TITLE
feat(vista): crear BarraEstado con información de la sesión activa #135

### DIFF
--- a/src/main/java/edu/sisinf/estante/controller/BarraEstadoController.java
+++ b/src/main/java/edu/sisinf/estante/controller/BarraEstadoController.java
@@ -1,0 +1,65 @@
+package edu.sisinf.estante.controller;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+
+/**
+ * Controller de la barra de estado al pie de la ventana principal.
+ * Muestra información contextual de la sesión: conexión activa,
+ * tiempo de la última query, filas afectadas y un mensaje libre.
+ * Es un componente puramente pasivo: solo muestra lo que se le indica.
+ */
+public class BarraEstadoController {
+
+    @FXML private Label labelConexion;
+    @FXML private Label labelTiempo;
+    @FXML private Label labelFilas;
+    @FXML private Label labelMensaje;
+
+    /**
+     * Actualiza el label de conexión activa.
+     *
+     * @param texto Nombre o descripción de la conexión activa.
+     *              Si es {@code null}, muestra "Sin conexión".
+     */
+    public void setConexion(String texto) {
+        labelConexion.setText(texto != null ? texto : "Sin conexión");
+    }
+
+    /**
+     * Actualiza el label de tiempo con el formato "X ms".
+     *
+     * @param ms Tiempo en milisegundos de la última query ejecutada.
+     */
+    public void setTiempo(long ms) {
+        labelTiempo.setText(ms + " ms");
+    }
+
+    /**
+     * Actualiza el label de filas con el formato "X filas".
+     *
+     * @param filas Número de filas devueltas o afectadas.
+     */
+    public void setFilas(int filas) {
+        labelFilas.setText(filas + " filas");
+    }
+
+    /**
+     * Actualiza el label de mensaje libre.
+     *
+     * @param mensaje Mensaje a mostrar. Si es {@code null}, muestra texto vacío.
+     */
+    public void setMensaje(String mensaje) {
+        labelMensaje.setText(mensaje != null ? mensaje : "");
+    }
+
+    /**
+     * Limpia los labels de tiempo, filas y mensaje.
+     * El label de conexión no se modifica.
+     */
+    public void limpiar() {
+        labelTiempo.setText("");
+        labelFilas.setText("");
+        labelMensaje.setText("");
+    }
+}


### PR DESCRIPTION

## ¿Qué hace este PR?
Crea BarraEstado.fxml con un HBox que contiene cuatro labels
(conexion, tiempo, filas, mensaje) separados verticalmente.
Crea BarraEstadoController.java con setters para cada label,
setConexion(null) muestra "Sin conexión", setMensaje(null) muestra
vacío y limpiar() vacía tiempo, filas y mensaje.


## Issue relacionado
Closes #135

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica