### PR TITLE
feat(vista): crear PanelEditorSQL con TextArea para escribir queries #132

### DIFF
--- a/src/main/java/edu/sisinf/estante/controller/PanelEditorSQLController.java
+++ b/src/main/java/edu/sisinf/estante/controller/PanelEditorSQLController.java
@@ -1,0 +1,85 @@
+package edu.sisinf.estante.controller;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+
+import java.util.function.Consumer;
+
+/**
+ * Controller del panel editor SQL.
+ * Permite al usuario escribir y ejecutar consultas SQL.
+ * El editor no ejecuta queries directamente: dispara un callback
+ * registrado externamente con el texto actual del editor.
+ */
+public class PanelEditorSQLController {
+
+    @FXML private Button btnEjecutar;
+    @FXML private Button btnLimpiar;
+    @FXML private Label labelConexionActiva;
+    @FXML private TextArea areaSQL;
+
+    private Consumer<String> onEjecutar;
+
+    /**
+     * Inicializa el controller conectando los botones y el atajo de teclado.
+     */
+    @FXML
+    public void initialize() {
+
+        // Botón limpiar
+        btnLimpiar.setOnAction(e -> areaSQL.clear());
+
+        // Botón ejecutar
+        btnEjecutar.setOnAction(e -> disparar());
+
+        // Ctrl+Enter dispara el callback sin agregar salto de línea
+        areaSQL.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.ENTER && event.isControlDown()) {
+                event.consume();
+                disparar();
+            }
+        });
+    }
+
+    /**
+     * Registra el callback que se invoca al ejecutar una query.
+     *
+     * @param callback {@code Consumer<String>} que recibe el texto del editor.
+     */
+    public void setOnEjecutar(Consumer<String> callback) {
+        this.onEjecutar = callback;
+    }
+
+    /**
+     * Actualiza el label de conexión activa.
+     *
+     * @param descripcion Descripción de la conexión activa.
+     *                    Si es {@code null}, muestra "Sin conexión".
+     */
+    public void setConexionActiva(String descripcion) {
+        labelConexionActiva.setText(descripcion != null ? descripcion : "Sin conexión");
+    }
+
+    /**
+     * Devuelve el texto actual del editor SQL.
+     *
+     * @return Texto escrito en el {@code TextArea}.
+     */
+    public String getTextoSQL() {
+        return areaSQL.getText();
+    }
+
+    /**
+     * Dispara el callback si el texto no está vacío.
+     */
+    private void disparar() {
+        String texto = areaSQL.getText();
+        if (onEjecutar != null && !texto.isBlank()) {
+            onEjecutar.accept(texto);
+        }
+    }
+}

--- a/src/main/resources/fxml/PanelEditorSQL.fxml
+++ b/src/main/resources/fxml/PanelEditorSQL.fxml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Separator?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.ToolBar?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx"
+      xmlns:fx="http://javafx.com/fxml"
+      fx:controller="edu.sisinf.estante.controller.PanelEditorSQLController"
+      VBox.vgrow="ALWAYS">
+
+    <ToolBar>
+        <Button fx:id="btnEjecutar" text="Ejecutar (Ctrl+Enter)"/>
+        <Button fx:id="btnLimpiar" text="Limpiar"/>
+        <Separator orientation="VERTICAL"/>
+        <Label fx:id="labelConexionActiva" text="Sin conexión"/>
+    </ToolBar>
+
+    <TextArea fx:id="areaSQL"
+              promptText="Escribe tu consulta SQL aquí..."
+              wrapText="false"
+              style="-fx-font-family: monospace;"
+              VBox.vgrow="ALWAYS"/>
+
+</VBox>


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea PanelEditorSQL.fxml con un VBox que contiene una ToolBar
con botones Ejecutar y Limpiar, label de conexión activa y un
TextArea con fuente monoespaciada. Crea PanelEditorSQLController.java
con setOnEjecutar(), setConexionActiva(), getTextoSQL() y soporte
para Ctrl+Enter. El callback no se invoca si el texto está vacío.


## Issue relacionado
Closes #132

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica