### PR TITLE
test(util,servicio): pruebas unitarias de SqlValidator y EjecutorQuery - Closes#136

### DIFF
--- a/src/test/java/edu/sisinf/estante/servicio/EjecutorQueryTest.java
+++ b/src/test/java/edu/sisinf/estante/servicio/EjecutorQueryTest.java
@@ -1,0 +1,170 @@
+package edu.sisinf.estante.servicio;
+
+import edu.sisinf.estante.modelo.ResultadoQuery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pruebas de integración pequeñas de EjecutorQuery.
+ * Usan SQLite en memoria para ser rápidas y deterministas.
+ */
+class EjecutorQueryTest {
+
+    private Connection conexion;
+    private EjecutorQuery ejecutor;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        // Cada test obtiene una base en memoria nueva (conexión nueva = BD nueva en SQLite)
+        conexion = DriverManager.getConnection("jdbc:sqlite::memory:");
+        ejecutor = new EjecutorQuery(conexion);
+
+        // Crear tabla con datos de prueba
+        conexion.createStatement().executeUpdate(
+            "CREATE TABLE usuarios (id INTEGER PRIMARY KEY, nombre TEXT, edad INTEGER)"
+        );
+        conexion.createStatement().executeUpdate("INSERT INTO usuarios VALUES (1, 'Ana', 30)");
+        conexion.createStatement().executeUpdate("INSERT INTO usuarios VALUES (2, 'Luis', 25)");
+        conexion.createStatement().executeUpdate("INSERT INTO usuarios VALUES (3, 'María', 35)");
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        // Cerrar la conexión elimina la base en memoria automáticamente
+        if (conexion != null && !conexion.isClosed()) {
+            conexion.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // SELECT
+    // -------------------------------------------------------------------------
+
+    @Test
+    void ejecutar_select_retornaTipoLectura() {
+        // Un SELECT debe producir un ResultadoQuery de tipo LECTURA
+        ResultadoQuery resultado = ejecutor.ejecutar("SELECT * FROM usuarios");
+        assertEquals(ResultadoQuery.Tipo.LECTURA, resultado.getTipo());
+    }
+
+    @Test
+    void ejecutar_select_contieneNombresDeColumnasCorrectos() {
+        // El resultado de un SELECT debe incluir los nombres exactos de las columnas
+        ResultadoQuery resultado = ejecutor.ejecutar("SELECT id, nombre, edad FROM usuarios");
+        assertEquals(3, resultado.getColumnas().size());
+        assertEquals("id",     resultado.getColumnas().get(0));
+        assertEquals("nombre", resultado.getColumnas().get(1));
+        assertEquals("edad",   resultado.getColumnas().get(2));
+    }
+
+    @Test
+    void ejecutar_select_contieneNumeroCorrectoDeFilas() {
+        // La tabla tiene 3 filas; el resultado debe reflejarlo
+        ResultadoQuery resultado = ejecutor.ejecutar("SELECT * FROM usuarios");
+        assertEquals(3, resultado.getFilas().size());
+    }
+
+    @Test
+    void ejecutar_select_contieneValoresCorrectosEnCadaCelda() {
+        // Los datos de la primera fila deben coincidir con lo insertado en setUp()
+        ResultadoQuery resultado = ejecutor.ejecutar("SELECT id, nombre, edad FROM usuarios WHERE id = 1");
+        assertEquals(1, resultado.getFilas().size());
+
+        var fila = resultado.getFilas().get(0);
+        assertEquals(1,     ((Number) fila.get(0)).intValue());
+        assertEquals("Ana", fila.get(1));
+        assertEquals(30,    ((Number) fila.get(2)).intValue());
+    }
+
+    // -------------------------------------------------------------------------
+    // INSERT
+    // -------------------------------------------------------------------------
+
+    @Test
+    void ejecutar_insert_retornaTipoEscritura() {
+        // Un INSERT debe producir un ResultadoQuery de tipo ESCRITURA
+        ResultadoQuery resultado = ejecutor.ejecutar(
+            "INSERT INTO usuarios VALUES (4, 'Carlos', 28)"
+        );
+        assertEquals(ResultadoQuery.Tipo.ESCRITURA, resultado.getTipo());
+    }
+
+    @Test
+    void ejecutar_insert_filasAfectadasEsUno() {
+        // Un INSERT de una fila debe reportar filasAfectadas == 1
+        ResultadoQuery resultado = ejecutor.ejecutar(
+            "INSERT INTO usuarios VALUES (4, 'Carlos', 28)"
+        );
+        assertEquals(1, resultado.getFilasAfectadas());
+    }
+
+    // -------------------------------------------------------------------------
+    // UPDATE y DELETE
+    // -------------------------------------------------------------------------
+
+    @Test
+    void ejecutar_update_retornaFilasAfectadasCorrecto() {
+        // UPDATE que modifica 2 filas debe reportar filasAfectadas == 2
+        ResultadoQuery resultado = ejecutor.ejecutar(
+            "UPDATE usuarios SET edad = 99 WHERE id IN (1, 2)"
+        );
+        assertEquals(2, resultado.getFilasAfectadas());
+    }
+
+    @Test
+    void ejecutar_delete_retornaFilasAfectadasCorrecto() {
+        // DELETE de una fila concreta debe reportar filasAfectadas == 1
+        ResultadoQuery resultado = ejecutor.ejecutar(
+            "DELETE FROM usuarios WHERE id = 3"
+        );
+        assertEquals(1, resultado.getFilasAfectadas());
+    }
+
+    // -------------------------------------------------------------------------
+    // ERROR
+    // -------------------------------------------------------------------------
+
+    @Test
+    void ejecutar_sqlInvalido_retornaTipoError() {
+        // SQL malformado debe producir un ResultadoQuery de tipo ERROR
+        ResultadoQuery resultado = ejecutor.ejecutar("SELECCION INVALIDA ??");
+        assertEquals(ResultadoQuery.Tipo.ERROR, resultado.getTipo());
+    }
+
+    @Test
+    void ejecutar_sqlInvalido_nuncaPropagaSQLException() {
+        // El ejecutor nunca debe propagar la excepción; el test pasa si no se lanza nada
+        assertDoesNotThrow(() -> ejecutor.ejecutar("ESTO NO ES SQL VALIDO"));
+    }
+
+    @Test
+    void ejecutar_sqlInvalido_mensajeErrorNoEsVacio() {
+        // El mensaje de error debe contener información útil (no estar vacío)
+        ResultadoQuery resultado = ejecutor.ejecutar("SELECT * FROM tabla_inexistente_xyz");
+        assertNotNull(resultado.getMensaje());
+        assertFalse(resultado.getMensaje().isBlank());
+    }
+
+    // -------------------------------------------------------------------------
+    // tiempoMs
+    // -------------------------------------------------------------------------
+
+    @Test
+    void ejecutar_tiempoMsEsNoNegativo() {
+        // El tiempo de ejecución siempre debe ser >= 0, independientemente del resultado
+        ResultadoQuery lectura  = ejecutor.ejecutar("SELECT * FROM usuarios");
+        ResultadoQuery escritura = ejecutor.ejecutar("INSERT INTO usuarios VALUES (10, 'X', 0)");
+        ResultadoQuery error    = ejecutor.ejecutar("SQL INVALIDO");
+
+        assertTrue(lectura.getTiempoMs()   >= 0);
+        assertTrue(escritura.getTiempoMs() >= 0);
+        assertTrue(error.getTiempoMs()     >= 0);
+    }
+}

--- a/src/test/java/edu/sisinf/estante/util/SqlValidatorTest.java
+++ b/src/test/java/edu/sisinf/estante/util/SqlValidatorTest.java
@@ -1,0 +1,205 @@
+package edu.sisinf.estante.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pruebas unitarias de SqlValidator.
+ * Cubren clasificación de tipo, lectura, DML, DDL y consultas destructivas.
+ */
+class SqlValidatorTest {
+
+    // -------------------------------------------------------------------------
+    // tipo() — reconocimiento de SELECT
+    // -------------------------------------------------------------------------
+
+    @Test
+    void tipo_selectEnMinusculas_retornaSelect() {
+        // Verifica que "select" en minúsculas se clasifica como SELECT
+        assertEquals(SqlValidator.TipoQuery.SELECT, SqlValidator.tipo("select * from libros"));
+    }
+
+    @Test
+    void tipo_selectEnMayusculas_retornaSelect() {
+        // Verifica que "SELECT" en mayúsculas se clasifica como SELECT
+        assertEquals(SqlValidator.TipoQuery.SELECT, SqlValidator.tipo("SELECT * FROM libros"));
+    }
+
+    @Test
+    void tipo_selectConEspaciosAlInicio_retornaSelect() {
+        // Verifica que los espacios iniciales no impiden la clasificación
+        assertEquals(SqlValidator.TipoQuery.SELECT, SqlValidator.tipo("   SELECT * FROM t"));
+    }
+
+    // -------------------------------------------------------------------------
+    // tipo() — reconocimiento de cada tipo DML/DDL
+    // -------------------------------------------------------------------------
+
+    @Test
+    void tipo_insert_retornaInsert() {
+        // Verifica que INSERT se identifica correctamente
+        assertEquals(SqlValidator.TipoQuery.INSERT, SqlValidator.tipo("INSERT INTO libros (id) VALUES (1)"));
+    }
+
+    @Test
+    void tipo_update_retornaUpdate() {
+        // Verifica que UPDATE se identifica correctamente
+        assertEquals(SqlValidator.TipoQuery.UPDATE, SqlValidator.tipo("UPDATE libros SET titulo='a' WHERE id=1"));
+    }
+
+    @Test
+    void tipo_delete_retornaDelete() {
+        // Verifica que DELETE se identifica correctamente
+        assertEquals(SqlValidator.TipoQuery.DELETE, SqlValidator.tipo("DELETE FROM libros WHERE id=1"));
+    }
+
+    @Test
+    void tipo_create_retornaCreate() {
+        // Verifica que CREATE se identifica correctamente
+        assertEquals(SqlValidator.TipoQuery.CREATE, SqlValidator.tipo("CREATE TABLE libros (id INT)"));
+    }
+
+    @Test
+    void tipo_drop_retornaDrop() {
+        // Verifica que DROP se identifica correctamente
+        assertEquals(SqlValidator.TipoQuery.DROP, SqlValidator.tipo("DROP TABLE libros"));
+    }
+
+    @Test
+    void tipo_alter_retornaAlter() {
+        // Verifica que ALTER se identifica correctamente
+        assertEquals(SqlValidator.TipoQuery.ALTER, SqlValidator.tipo("ALTER TABLE libros ADD COLUMN autor TEXT"));
+    }
+
+    // -------------------------------------------------------------------------
+    // tipo() — casos DESCONOCIDO
+    // -------------------------------------------------------------------------
+
+    @Test
+    void tipo_null_retornaDesconocido() {
+        // null no tiene tipo reconocible
+        assertEquals(SqlValidator.TipoQuery.DESCONOCIDO, SqlValidator.tipo(null));
+    }
+
+    @Test
+    void tipo_cadenaVacia_retornaDesconocido() {
+        // Cadena vacía no tiene tipo reconocible
+        assertEquals(SqlValidator.TipoQuery.DESCONOCIDO, SqlValidator.tipo(""));
+    }
+
+    @Test
+    void tipo_soloEspacios_retornaDesconocido() {
+        // Cadena de sólo espacios no tiene tipo reconocible
+        assertEquals(SqlValidator.TipoQuery.DESCONOCIDO, SqlValidator.tipo("   "));
+    }
+
+    @Test
+    void tipo_explain_retornaDesconocido() {
+        // EXPLAIN no es un tipo reconocido por SqlValidator
+        assertEquals(SqlValidator.TipoQuery.DESCONOCIDO, SqlValidator.tipo("EXPLAIN SELECT * FROM libros"));
+    }
+
+    // -------------------------------------------------------------------------
+    // esLectura()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void esLectura_conSelect_retornaTrue() {
+        // Solo SELECT es una consulta de lectura
+        assertTrue(SqlValidator.esLectura("SELECT 1"));
+    }
+
+    @Test
+    void esLectura_conInsert_retornaFalse() {
+        // INSERT no es lectura
+        assertFalse(SqlValidator.esLectura("INSERT INTO libros (id) VALUES (1)"));
+    }
+
+    // -------------------------------------------------------------------------
+    // esDML()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void esDML_paraInsertUpdateDelete_retornaTrue() {
+        // INSERT, UPDATE y DELETE son DML
+        assertTrue(SqlValidator.esDML("INSERT INTO libros (id) VALUES (1)"));
+        assertTrue(SqlValidator.esDML("UPDATE libros SET titulo='a' WHERE id=1"));
+        assertTrue(SqlValidator.esDML("DELETE FROM libros WHERE id=1"));
+    }
+
+    @Test
+    void esDML_paraSelectYDDL_retornaFalse() {
+        // SELECT, CREATE, DROP y ALTER no son DML
+        assertFalse(SqlValidator.esDML("SELECT * FROM libros"));
+        assertFalse(SqlValidator.esDML("CREATE TABLE libros (id INT)"));
+        assertFalse(SqlValidator.esDML("DROP TABLE libros"));
+        assertFalse(SqlValidator.esDML("ALTER TABLE libros ADD COLUMN autor TEXT"));
+    }
+
+    // -------------------------------------------------------------------------
+    // esDDL()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void esDDL_paraCreateDropAlter_retornaTrue() {
+        // CREATE, DROP y ALTER son DDL
+        assertTrue(SqlValidator.esDDL("CREATE TABLE libros (id INT)"));
+        assertTrue(SqlValidator.esDDL("DROP TABLE libros"));
+        assertTrue(SqlValidator.esDDL("ALTER TABLE libros ADD COLUMN autor TEXT"));
+    }
+
+    @Test
+    void esDDL_paraSelectYDML_retornaFalse() {
+        // SELECT, INSERT, UPDATE y DELETE no son DDL
+        assertFalse(SqlValidator.esDDL("SELECT * FROM libros"));
+        assertFalse(SqlValidator.esDDL("INSERT INTO libros (id) VALUES (1)"));
+        assertFalse(SqlValidator.esDDL("UPDATE libros SET titulo='a' WHERE id=1"));
+        assertFalse(SqlValidator.esDDL("DELETE FROM libros WHERE id=1"));
+    }
+
+    // -------------------------------------------------------------------------
+    // esDestructiva()
+    // -------------------------------------------------------------------------
+
+    @Test
+    void esDestructiva_delete_retornaTrue() {
+        // DELETE siempre es destructivo
+        assertTrue(SqlValidator.esDestructiva("DELETE FROM users"));
+    }
+
+    @Test
+    void esDestructiva_drop_retornaTrue() {
+        // DROP siempre es destructivo
+        assertTrue(SqlValidator.esDestructiva("DROP TABLE users"));
+    }
+
+    @Test
+    void esDestructiva_updateSinWhere_retornaTrue() {
+        // UPDATE sin WHERE es destructivo porque afecta todas las filas
+        assertTrue(SqlValidator.esDestructiva("UPDATE users SET nombre='a'"));
+    }
+
+    @Test
+    void esDestructiva_updateConWhere_retornaFalse() {
+        // UPDATE con WHERE no es destructivo (acotado por condición)
+        assertFalse(SqlValidator.esDestructiva("UPDATE users SET nombre='a' WHERE id=1"));
+    }
+
+    @Test
+    void esDestructiva_updateConWhereCaseInsensitive_retornaFalse() {
+        // La detección de WHERE es case-insensitive
+        assertFalse(SqlValidator.esDestructiva("update USERS set nombre='a' where id=1"));
+    }
+
+    @Test
+    void esDestructiva_select_retornaFalse() {
+        // SELECT nunca es destructivo
+        assertFalse(SqlValidator.esDestructiva("SELECT * FROM users"));
+    }
+
+    @Test
+    void esDestructiva_insert_retornaFalse() {
+        // INSERT no es destructivo
+        assertFalse(SqlValidator.esDestructiva("INSERT INTO users (id) VALUES (1)"));
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Se crean dos archivos de prueba con JUnit 5 para cubrir las clases centrales `SqlValidator` y `EjecutorQuery`.
`SqlValidatorTest` verifica el método `tipo()` con queries en distintas capitalizaciones y con espacios iniciales, cubre los 7 tipos reconocidos (`SELECT`, `INSERT`, `UPDATE`, `DELETE`, `CREATE`, `DROP`, `ALTER`) y los casos que deben retornar `DESCONOCIDO` (null, vacío, solo espacios, keyword no reconocida). También prueba `esLectura()`, `esDML()`, `esDDL()` y `esDestructiva()`, incluyendo la distinción entre `UPDATE` con y sin `WHERE` de forma case-insensitive.
`EjecutorQueryTest` usa una base de datos SQLite en memoria creada en `@BeforeEach` y cerrada en `@AfterEach`. Verifica que un `SELECT` retorna tipo `LECTURA` con columnas, filas y valores correctos; que `INSERT`, `UPDATE` y `DELETE` retornan tipo `ESCRITURA` con `filasAfectadas` correcto; que SQL inválido retorna tipo `ERROR` con mensaje no vacío sin propagar `SQLException`; y que `tiempoMs` es siempre no negativo.

## Issue relacionado
Closes #136

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
mvn test
No pasa todas las pruebas; existe un problema ajeno al Issue #136, tomado por mí persona, el cual es el siguiente:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e65e16f0-5771-4bc3-b95f-04dcaffb745d" />

``` [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.12.1:compile (default-compile) on project estante: Compilation failure: Compilation failure: 
[ERROR] /E:/Repositorio/estante/src/main/java/edu/sisinf/estante/core/HistorialConsultas.java:[1,1] illegal character: '`'
[ERROR] /E:/Repositorio/estante/src/main/java/edu/sisinf/estante/core/HistorialConsultas.java:[1,2] illegal character: '`'
[ERROR] /E:/Repositorio/estante/src/main/java/edu/sisinf/estante/core/HistorialConsultas.java:[1,3] illegal character: '`'
[ERROR] /E:/Repositorio/estante/src/main/java/edu/sisinf/estante/core/HistorialConsultas.java:[1,9] class, interface, enum, or record expected
[ERROR] /E:/Repositorio/estante/src/main/java/edu/sisinf/estante/core/HistorialConsultas.java:[4,1] class, interface, enum, or record expected
[ERROR] /E:/Repositorio/estante/src/main/java/edu/sisinf/estante/core/HistorialConsultas.java:[5,1] class, interface, enum, or record expected
[ERROR] /E:/Repositorio/estante/src/main/java/edu/sisinf/estante/core/HistorialConsultas.java:[6,1] class, interface, enum, or record expected
[ERROR] /E:/Repositorio/estante/src/main/java/edu/sisinf/estante/core/HistorialConsultas.java:[7,1] class, interface, enum, or record expected
[ERROR] /E:/Repositorio/estante/src/main/java/edu/sisinf/estante/core/HistorialConsultas.java:[49,1] illegal character: '`'
[ERROR] /E:/Repositorio/estante/src/main/java/edu/sisinf/estante/core/HistorialConsultas.java:[49,2] illegal character: '`'
[ERROR] /E:/Repositorio/estante/src/main/java/edu/sisinf/estante/core/HistorialConsultas.java:[49,3] illegal character: '`'
[ERROR] /E:/Repositorio/estante/src/main/java/edu/sisinf/estante/core/HistorialConsultas.java:[50,1] reached end of file while parsing
[ERROR] -> [Help 1]


