### PR TITLE
feat(vista): crear DialogoNuevaConexion para configurar conexiones

### DIFF
--- a/src/main/java/edu/sisinf/estante/controller/DialogoNuevaConexionController.java
+++ b/src/main/java/edu/sisinf/estante/controller/DialogoNuevaConexionController.java
@@ -1,0 +1,185 @@
+// ============================================================
+// ARCHIVO 2: DialogoNuevaConexionController.java
+// RUTA: src/main/java/edu/sisinf/estante/controller/DialogoNuevaConexionController.java
+// ============================================================
+ 
+package edu.sisinf.estante.controller;
+ 
+import edu.sisinf.estante.modelo.Conexion;
+import edu.sisinf.estante.modelo.TipoMotor;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.PasswordField;
+import javafx.scene.control.TextField;
+import javafx.stage.Stage;
+ 
+/**
+ * Controller del diálogo modal para crear una nueva conexión.
+ *
+ * <p>Este controller es deliberadamente "tonto": no contiene lógica de persistencia
+ * ni de prueba de conexión. Solo gestiona la UI y construye el objeto {@link Conexion}
+ * con los datos ingresados por el usuario.</p>
+ *
+ * <p>Los handlers de los botones "Probar" y "Guardar" se inyectan desde fuera
+ * del controller para mantener bajo el acoplamiento con los servicios.</p>
+ */
+public class DialogoNuevaConexionController {
+ 
+    // --------------------------------------------------------
+    // FXML fields
+    // --------------------------------------------------------
+ 
+    @FXML private TextField     campoNombre;
+    @FXML private ComboBox<TipoMotor> comboMotor;
+    @FXML private TextField     campoHost;
+    @FXML private TextField     campoPuerto;
+    @FXML private TextField     campoBaseDatos;
+    @FXML private TextField     campoUsuario;
+    @FXML private PasswordField campoPassword;
+    @FXML private Label         etiquetaEstado;
+    @FXML private Button        botonProbar;
+    @FXML private Button        botonGuardar;
+    @FXML private Button        botonCancelar;
+ 
+    /** Resultado del diálogo. Es null si el usuario canceló. */
+    private Conexion conexionResultado;
+ 
+    // --------------------------------------------------------
+    // Initialization
+    // --------------------------------------------------------
+ 
+    /**
+     * Inicializa el diálogo:
+     * <ul>
+     *   <li>Llena el ComboBox con los valores de {@link TipoMotor}.</li>
+     *   <li>Selecciona SQLITE por defecto y deshabilita los campos que no aplican.</li>
+     *   <li>Registra el listener del ComboBox para habilitar/deshabilitar campos.</li>
+     *   <li>Conecta el botón "Cancelar" para cerrar el diálogo.</li>
+     * </ul>
+     */
+    @FXML
+    public void initialize() {
+        comboMotor.getItems().addAll(TipoMotor.values());
+        comboMotor.setValue(TipoMotor.SQLITE);
+        actualizarCamposSegunMotor(TipoMotor.SQLITE);
+ 
+        comboMotor.valueProperty().addListener(
+                (observable, oldValue, newValue) -> actualizarCamposSegunMotor(newValue)
+        );
+ 
+        botonCancelar.setOnAction(event -> cerrar());
+    }
+ 
+    // --------------------------------------------------------
+    // Private helpers
+    // --------------------------------------------------------
+ 
+    /**
+     * Habilita o deshabilita los campos de red según el motor seleccionado.
+     * SQLite no requiere host, puerto, usuario ni password.
+     *
+     * @param motor motor seleccionado en el ComboBox
+     */
+    private void actualizarCamposSegunMotor(TipoMotor motor) {
+        boolean esSqlite = motor == TipoMotor.SQLITE;
+        campoHost.setDisable(esSqlite);
+        campoPuerto.setDisable(esSqlite);
+        campoUsuario.setDisable(esSqlite);
+        campoPassword.setDisable(esSqlite);
+    }
+ 
+    /**
+     * Cierra el diálogo sin guardar.
+     * El resultado queda como {@code null}.
+     */
+    private void cerrar() {
+        ((Stage) botonCancelar.getScene().getWindow()).close();
+    }
+ 
+    // --------------------------------------------------------
+    // Public API
+    // --------------------------------------------------------
+ 
+    /**
+     * Construye un objeto {@link Conexion} con los valores actuales del formulario.
+     *
+     * <ul>
+     *   <li>Si el campo "Puerto" está vacío, el puerto del objeto será {@code null}.</li>
+     *   <li>Si el campo "Puerto" contiene un valor no numérico, el puerto será {@code null}.</li>
+     *   <li>Los demás campos se copian directamente desde los controles.</li>
+     * </ul>
+     *
+     * @return objeto {@link Conexion} armado con los datos del formulario
+     */
+    public Conexion construirConexion() {
+        Conexion conexion = new Conexion();
+        conexion.setNombre(campoNombre.getText());
+        conexion.setTipoMotor(comboMotor.getValue());
+        conexion.setHost(campoHost.getText());
+        conexion.setBasedatos(campoBaseDatos.getText());
+        conexion.setUsuario(campoUsuario.getText());
+        conexion.setPassword(campoPassword.getText());
+ 
+        String puertoTexto = campoPuerto.getText();
+        if (puertoTexto != null && !puertoTexto.isBlank()) {
+            try {
+                conexion.setPuerto(Integer.parseInt(puertoTexto.strip()));
+            } catch (NumberFormatException e) {
+                conexion.setPuerto(null);
+            }
+        } else {
+            conexion.setPuerto(null);
+        }
+ 
+        return conexion;
+    }
+ 
+    /**
+     * Devuelve la conexión resultado del diálogo.
+     * Es {@code null} si el usuario canceló sin guardar.
+     *
+     * @return conexión guardada o {@code null}
+     */
+    public Conexion getConexionResultado() {
+        return conexionResultado;
+    }
+ 
+    /**
+     * Establece la conexión resultado del diálogo.
+     * La integración llama a este método tras validar y persistir la conexión.
+     *
+     * @param conexion conexión a establecer como resultado
+     */
+    public void setConexionResultado(Conexion conexion) {
+        this.conexionResultado = conexion;
+    }
+ 
+    /**
+     * Devuelve el botón "Probar" para que la integración le conecte su handler.
+     *
+     * @return botón Probar
+     */
+    public Button getBotonProbar() {
+        return botonProbar;
+    }
+ 
+    /**
+     * Devuelve el botón "Guardar" para que la integración le conecte su handler.
+     *
+     * @return botón Guardar
+     */
+    public Button getBotonGuardar() {
+        return botonGuardar;
+    }
+ 
+    /**
+     * Devuelve la etiqueta de estado para que la integración muestre mensajes al usuario.
+     *
+     * @return etiqueta de estado
+     */
+    public Label getEtiquetaEstado() {
+        return etiquetaEstado;
+    }
+}

--- a/src/main/resources/fxml/DialogoNuevaConexion.fxml
+++ b/src/main/resources/fxml/DialogoNuevaConexion.fxml
@@ -1,0 +1,70 @@
+// ============================================================
+// ARCHIVO 1: DialogoNuevaConexion.fxml
+// RUTA: src/main/resources/fxml/DialogoNuevaConexion.fxml
+// ============================================================
+ 
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.PasswordField?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+ 
+<VBox xmlns:fx="http://javafx.com/fxml"
+      fx:controller="edu.sisinf.estante.controller.DialogoNuevaConexionController"
+      prefWidth="400.0"
+      spacing="12.0"
+      style="-fx-padding: 15;">
+ 
+    <Label text="Nueva conexión" style="-fx-font-size: 16px; -fx-font-weight: bold;" />
+ 
+    <GridPane hgap="10" vgap="8">
+        <columnConstraints>
+            <ColumnConstraints minWidth="110" />
+            <ColumnConstraints hgrow="ALWAYS" />
+        </columnConstraints>
+ 
+        <!-- Nombre -->
+        <Label text="Nombre:" GridPane.rowIndex="0" GridPane.columnIndex="0" />
+        <TextField fx:id="campoNombre" GridPane.rowIndex="0" GridPane.columnIndex="1" />
+ 
+        <!-- Motor -->
+        <Label text="Motor:" GridPane.rowIndex="1" GridPane.columnIndex="0" />
+        <ComboBox fx:id="comboMotor" maxWidth="Infinity" GridPane.rowIndex="1" GridPane.columnIndex="1" />
+ 
+        <!-- Host -->
+        <Label text="Host:" GridPane.rowIndex="2" GridPane.columnIndex="0" />
+        <TextField fx:id="campoHost" GridPane.rowIndex="2" GridPane.columnIndex="1" />
+ 
+        <!-- Puerto -->
+        <Label text="Puerto:" GridPane.rowIndex="3" GridPane.columnIndex="0" />
+        <TextField fx:id="campoPuerto" GridPane.rowIndex="3" GridPane.columnIndex="1" />
+ 
+        <!-- Base de datos -->
+        <Label text="Base de datos:" GridPane.rowIndex="4" GridPane.columnIndex="0" />
+        <TextField fx:id="campoBaseDatos" GridPane.rowIndex="4" GridPane.columnIndex="1" />
+ 
+        <!-- Usuario -->
+        <Label text="Usuario:" GridPane.rowIndex="5" GridPane.columnIndex="0" />
+        <TextField fx:id="campoUsuario" GridPane.rowIndex="5" GridPane.columnIndex="1" />
+ 
+        <!-- Password -->
+        <Label text="Password:" GridPane.rowIndex="6" GridPane.columnIndex="0" />
+        <PasswordField fx:id="campoPassword" GridPane.rowIndex="6" GridPane.columnIndex="1" />
+    </GridPane>
+ 
+    <!-- Mensaje de estado -->
+    <Label fx:id="etiquetaEstado" text="" wrapText="true" />
+ 
+    <!-- Botones -->
+    <HBox spacing="8" alignment="CENTER_RIGHT">
+        <Button fx:id="botonProbar" text="Probar" />
+        <Button fx:id="botonGuardar" text="Guardar" />
+        <Button fx:id="botonCancelar" text="Cancelar" />
+    </HBox>
+ 
+</VBox>


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea el diálogo modal para configurar nuevas conexiones. Incluye el archivo FXML `DialogoNuevaConexion.fxml` con el formulario (nombre, motor, host, puerto, base de datos, usuario y password), etiqueta de estado y botones "Probar", "Guardar" y "Cancelar". También crea `DialogoNuevaConexionController.java` que inicializa el ComboBox con los valores de `TipoMotor`, deshabilita los campos de red al seleccionar SQLite, cierra el diálogo al cancelar y expone `construirConexion()` para armar el objeto `Conexion` con los datos del formulario.

## Issue relacionado
Closes #130 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica