### PR TITLE
fix: corregir pom.xml para asegurar version de Java 21 en el compilador

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
+                    <source>21</source>
+                    <target>21</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## ¿Qué hace este PR?
Actualiza la configuración del archivo `pom.xml` en la sección del `maven-compiler-plugin` para establecer explícitamente las propiedades `source` y `target` en la versión de Java 21, asegurando la consistencia con el JDK y las dependencias del proyecto (JavaFX 21.0.2).

## Issue relacionado
Closes #238

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
Compilación del proyecto validada de forma local ejecutando el ciclo de vida de Maven de manera exitosa:
<img width="1360" height="711" alt="image" src="https://github.com/user-attachments/assets/85b0358e-a2e6-4525-9ff0-f7562768b780" />
