### PR TITLE
fix: corregir exclusiones de Maven e IDE en gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ id_rsa.pub
 # Otros
 .eslintcache
 .gitignore.local
+
+*.iml
+*.class


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige el archivo `.gitignore` agregando exclusiones faltantes para artefactos de compilación Java/Maven y archivos generados por IDEs.

Reglas agregadas:

* `*.iml`
* `*.class`

Esto evita que archivos temporales, configuraciones locales y artefactos compilados aparezcan en `git status` o sean versionados accidentalmente.

## Issue relacionado
Closes #246 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica.