### PR TITLE
fix: validar sentencias nulas o vacías en SqlValidator

### DIFF
--- a/src/main/java/edu/sisinf/estante/util/SqlValidator.java
+++ b/src/main/java/edu/sisinf/estante/util/SqlValidator.java
@@ -4,6 +4,7 @@ import java.util.Locale;
 
 public class SqlValidator {
 
+
     public enum TipoQuery {
         SELECT,
         INSERT,
@@ -91,4 +92,12 @@ public class SqlValidator {
     private static boolean contieneWhere(String query) {
         return normalizar(query).matches("(?s).*\\bWHERE\\b.*");
     }
+    public static boolean esSentenciaValida(String query) {
+    if (query == null) {
+        return false;
+    }
+
+    return !normalizar(query).isEmpty();
+    }
 }
+


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige `SqlValidator.java` agregando el método `esSentenciaValida()` para validar correctamente sentencias SQL inválidas.

El método ahora retorna `false` cuando recibe:

* `null`
* cadena vacía `""`
* cadenas con solo espacios

Y retorna `true` para sentencias válidas como:

## Issue relacionado
Closes #245 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica.