### PR TITLE
fix: corregir ConfiguracionApp.java para que asegurarDirectorioHome()…

### DIFF
--- a/src/main/java/edu/sisinf/estante/config/ConfiguracionApp.java
+++ b/src/main/java/edu/sisinf/estante/config/ConfiguracionApp.java
@@ -5,6 +5,8 @@
 package edu.sisinf.estante.config;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -16,8 +18,8 @@ import java.nio.file.Paths;
  * <p>La aplicacion almacena sus archivos en un directorio oculto dentro del
  * home del usuario:</p>
  * <ul>
- *   <li>Linux / macOS: {@code ~/.estante/}</li>
- *   <li>Windows: {@code C:\Users\<usuario>\.estante\}</li>
+ * <li>Linux / macOS: {@code ~/.estante/}</li>
+ * <li>Windows: {@code C:\Users\<usuario>\.estante\}</li>
  * </ul>
  */
 public class ConfiguracionApp {
@@ -64,6 +66,10 @@ public class ConfiguracionApp {
      * <p>Solo crea el directorio; no crea ningun archivo dentro de el.</p>
      */
     public static void asegurarDirectorioHome() {
-        directorioHome().toFile().mkdirs();
+        try {
+            Files.createDirectories(directorioHome());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Verifica y corrige el método `asegurarDirectorioHome()` en `ConfiguracionApp.java`. Se reemplazó la implementación anterior por el uso explícito de `Files.createDirectories()`, cumpliendo estrictamente con el requerimiento de asegurar la idempotencia del método mediante las APIs nativas de `java.nio.file`. De esta forma, si el directorio oculto ya existe, el método retorna exitosamente sin lanzar excepciones (`FileAlreadyExistsException`) ni alterar el contenido del directorio.

## Issue relacionado
Closes #236

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1307" height="585" alt="image" src="https://github.com/user-attachments/assets/1bdd0759-253c-49ec-8b8f-df30de82867d" />
