### PR TITLE
fix: limpiar codigo temporal de Main

### DIFF
--- a/src/main/java/edu/sisinf/estante/Main.java
+++ b/src/main/java/edu/sisinf/estante/Main.java
@@ -1,11 +1,13 @@
-import edu.sisinf.estante.util.SqlValidator;
+package edu.sisinf.estante;
 
+/**
+ * Punto de entrada temporal de la aplicación Estante.
+ *
+ * La integración principal aún no está disponible.
+ */
 public class Main {
+
     public static void main(String[] args) {
-        System.out.println(SqlValidator.tipo("select * from t"));
-        System.out.println(SqlValidator.tipo("CREATE TABLE x (id INT)"));
-        System.out.println(SqlValidator.esDestructiva("DELETE FROM users"));
-        System.out.println(SqlValidator.esDestructiva("UPDATE users SET nombre='a'"));
-        System.out.println(SqlValidator.esDestructiva("UPDATE users SET nombre='a' WHERE id=1"));
+        System.out.println("Estante aún no está integrado.");
     }
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Limpia Main.java eliminando código de prueba hardcodeado relacionado con SqlValidator y deja un punto de entrada temporal simple para la aplicación.

## Issue relacionado
Closes #230 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Main.java ahora contiene únicamente un mensaje temporal indicando que la aplicación aún no está integrada.