### PR TITLE
fix: corregir SqlValidator.java para que isSelect() ignore espacios y mayúsculas

### DIFF
--- a/src/main/java/edu/sisinf/estante/util/SqlValidator.java
+++ b/src/main/java/edu/sisinf/estante/util/SqlValidator.java
@@ -99,5 +99,22 @@ public class SqlValidator {
 
     return !normalizar(query).isEmpty();
     }
+    // ==================== METODOS INDIVIDUALES REQUERIDOS ====================
+    
+    public static boolean isSelect(String query) {
+        return esLectura(query);
+    }
+
+    public static boolean isInsert(String query) {
+        return tipo(query) == TipoQuery.INSERT;
+    }
+
+    public static boolean isUpdate(String query) {
+        return tipo(query) == TipoQuery.UPDATE;
+    }
+
+    public static boolean isDelete(String query) {
+        return tipo(query) == TipoQuery.DELETE;
+    }
 }
 


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega los métodos `isSelect()`, `isInsert()`, `isUpdate()` e `isDelete()` en `SqlValidator.java` como alias de los métodos en español existentes. Todos son case-insensitive y toleran espacios iniciales gracias al método `normalizar()` que ya aplica `strip()` y `toUpperCase()` internamente.
Los métodos existentes no fueron modificados para no romper componentes que ya dependan de ellos.

## Issue relacionado
Closes #239 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="810" height="768" alt="image" src="https://github.com/user-attachments/assets/a05aafda-6940-4b82-8572-061e748f7374" />
