### PR TITLE
fix: corregir DialogoConfirmacionDML.java para que el TextArea del SQL sea de solo lectura 

### DIFF
--- a/src/main/java/edu/sisinf/estante/controller/DialogoConfirmacionDML.java
+++ b/src/main/java/edu/sisinf/estante/controller/DialogoConfirmacionDML.java
@@ -1,7 +1,7 @@
 package edu.sisinf.estante.controller;
 
-import edu.sisinf.estante.SqlValidator;
-import edu.sisinf.estante.TipoQuery;
+import edu.sisinf.estante.util.SqlValidator;
+import edu.sisinf.estante.util.SqlValidator.TipoQuery;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Label;


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige los imports en `DialogoConfirmacionDML.java` que apuntaban a paquetes inexistentes (`edu.sisinf.estante.SqlValidator` y `edu.sisinf.estante.TipoQuery`).
Se actualizaron a `edu.sisinf.estante.util.SqlValidator` y `edu.sisinf.estante.util.SqlValidator.TipoQuery`. 
El `TextArea` que muestra la sentencia SQL ya contaba con `setEditable(false)` y `setWrapText(true)`, garantizando que el usuario no pueda modificar la sentencia en el diálogo.


## Issue relacionado
Closes #234 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="889" height="768" alt="image" src="https://github.com/user-attachments/assets/03eebc9a-f246-49ea-a342-20bbfdce61ce" />
<img width="555" height="178" alt="image" src="https://github.com/user-attachments/assets/51c4539d-5c3c-4d65-99ad-b6ee30680646" />
