### PR TITLE
fix: verificar prefijos de nivel en LoggerConsole

### DIFF
--- a/src/main/java/edu/sisinf/estante/util/LoggerConsole.java
+++ b/src/main/java/edu/sisinf/estante/util/LoggerConsole.java
@@ -12,7 +12,8 @@ public class LoggerConsole {
     private static LoggerConsole instancia;
     private static final DateTimeFormatter FORMATO = DateTimeFormatter.ofPattern("HH:mm:ss");
 
-    private LoggerConsole() {}
+    private LoggerConsole() {
+    }
 
     public static LoggerConsole getInstancia() {
         if (instancia == null) {


### PR DESCRIPTION
## ¿Qué hace este PR?
Se revisó LoggerConsole.java para verificar que los métodos de registro utilicen correctamente los prefijos de nivel esperados en consola.

Verificaciones realizadas:

info() utiliza el prefijo [INFO]
warn() utiliza el prefijo [WARN]
error() utiliza el prefijo [ERROR]

## Issue relacionado
Closes #241 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas