### PR TITLE
Fix/gitignore maven ide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,11 @@ target/
 *.dll
 *.so
 
+
 # IDEs / Editores
 .vscode/
 .idea/
+*.iml
 *.swp
 *.swo
 
@@ -59,6 +61,7 @@ htmlcov/
 *.dumps
 
 # Java
+*.class
 .classpath
 .project
 .settings/
@@ -90,5 +93,3 @@ id_rsa.pub
 .eslintcache
 .gitignore.local
 
-*.iml
-*.class

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ id_rsa.pub
 # Otros
 .eslintcache
 .gitignore.local
+
+*.iml
+*.class


### PR DESCRIPTION
## ¿Qué hace este PR?
Reorganiza y corrige las exclusiones relacionadas con Maven, Java e IDEs dentro de .gitignore.

Se verificó que el archivo incluya correctamente las reglas requeridas para evitar el versionado accidental de:

artefactos compilados (*.class, target/)
configuraciones de IDE (.idea/, *.iml)
archivos de configuración Java/Maven (.classpath, .project, .settings/)

Además, las reglas fueron ubicadas dentro de sus secciones correspondientes para mantener consistencia y legibilidad en el archivo.

## Issue relacionado
Closes #246 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica 