### PR TITLE
fix: corregir DialogoConfirmacionDML.java para que distinga correctamente entre WARNING y CONFIRMATION - Closes #235

### DIFF
--- a/src/main/java/edu/sisinf/estante/controller/DialogoConfirmacionDML.java
+++ b/src/main/java/edu/sisinf/estante/controller/DialogoConfirmacionDML.java
@@ -1,7 +1,6 @@
 package edu.sisinf.estante.controller;
 
-import edu.sisinf.estante.SqlValidator;
-import edu.sisinf.estante.TipoQuery;
+import edu.sisinf.estante.util.SqlValidator;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Label;
@@ -25,7 +24,7 @@ public class DialogoConfirmacionDML {
     public static boolean confirmar(String sql) {
 
         // 1. Clasificar la query
-        TipoQuery tipo = SqlValidator.tipo(sql);
+        SqlValidator.TipoQuery tipo = SqlValidator.tipo(sql);
 
         // 2. Determinar si es destructiva
         boolean esDestructiva = SqlValidator.esDestructiva(sql);


### PR DESCRIPTION
## ¿Qué hace este PR?
Se corrige el comportamiento del componente `DialogoConfirmacionDML.java` para que evalúe y diferencie de forma correcta el tipo de alerta (`AlertType`) que debe mostrar al usuario antes de ejecutar una sentencia en la base de datos.

## Issue relacionado
Closes #235 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica