### PR TITLE
fix: verify JDBC resource closing in executeSelect

### DIFF
--- a/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
+++ b/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
@@ -86,6 +86,7 @@ public class ConnectionProvider {
         } catch (SQLException e) {
             throw new ErrorQuery("Error al ejecutar la sentencia SELECT: " + e.getMessage(), e);
         } finally {
+             // Cierre seguro de recursos JDBC para evitar fugas de conexión
             if (resultSet != null) {
                 try { resultSet.close(); } catch (SQLException ignored) {}
             }


### PR DESCRIPTION
## ¿Qué hace este PR?

Se revisó la implementación de `executeSelect()` en `ConnectionProvider.java` para verificar el manejo correcto de recursos JDBC utilizados durante consultas SELECT.

Durante la revisión se confirmó que:

* `ResultSet` se cierra correctamente dentro de un bloque `finally`
* `Statement` también se cierra correctamente en `finally`
* las excepciones originales no se pierden durante el cierre de recursos
* el método mantiene intacta su lógica y tipo de retorno

Además, se añadieron comentarios aclaratorios para documentar explícitamente el cierre seguro de recursos y facilitar el mantenimiento del código.

## Issue relacionado
Closes #231

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Archivo revisado:

* `src/main/java/edu/sisinf/estante/core/ConnectionProvider.java`

Se verificó que el método `executeSelect()` ya implementaba correctamente el cierre de `Statement` y `ResultSet` mediante `finally`, evitando posibles fugas de recursos JDBC.