### PR TITLE
fix: corregir DialogoConfirmacionDML.java para que el TextArea del SQL sea de solo lectura

### DIFF
--- a/src/main/java/edu/sisinf/estante/controller/DialogoConfirmacionDML.java
+++ b/src/main/java/edu/sisinf/estante/controller/DialogoConfirmacionDML.java
@@ -53,8 +53,8 @@ public class DialogoConfirmacionDML {
         Label label = new Label("Vas a ejecutar la siguiente consulta:");
 
         TextArea textArea = new TextArea(sql);
-        textArea.setEditable(false);
-        textArea.setWrapText(true);
+        textArea.setEditable(false);    // Impide que el usuario modifique la consulta SQL en el cuadro de dialogo
+        textArea.setWrapText(true);    // Garantiza que las sentencias largas sean completamente visibles
         textArea.setPrefRowCount(6);
 
         VBox vbox = new VBox(8, label, textArea);


### PR DESCRIPTION
## ¿Qué hace este PR?
Se verificó que ```textArea.setEditable(false)``` está presente en línea 56 y ```textArea.setWrapText(true)``` en línea 57. Ambas propiedades garantizan que el usuario no pueda editar el SQL y que sentencias largas se muestren completas.


## Issue relacionado
Closes #234 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1027" height="768" alt="image" src="https://github.com/user-attachments/assets/8f2137d7-a5b9-4d40-81bb-fd05a6591d61" />
