### PR TITLE
fix: corregir executeUpdate() para que rechace explícitamente sentencias SELECT  #232

### DIFF
--- a/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
+++ b/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
@@ -110,16 +110,19 @@ public class ConnectionProvider {
      * @throws ErrorQuery               si ocurre un error durante la ejecución SQL
      */
     public static int executeUpdate(Connection connection, String sql) throws IllegalArgumentException, ErrorQuery {
-        if (SqlValidator.esLectura(sql)) {
-            throw new IllegalArgumentException(
-                    "executeUpdate() no acepta sentencias SELECT. Use executeQuery() para lecturas."
-            );
-        }
 
-        try (Statement statement = connection.createStatement()) {
-            return statement.executeUpdate(sql);
-        } catch (SQLException e) {
-            throw new ErrorQuery("Error al ejecutar la sentencia de escritura: " + e.getMessage(), e);
-        }
+    if (sql == null || sql.trim().toUpperCase().startsWith("SELECT")) {
+        throw new IllegalArgumentException(
+                "executeUpdate() no permite sentencias SELECT. Use executeSelect() para consultas."
+        );
     }
+
+    try (Statement statement = connection.createStatement()) {
+        return statement.executeUpdate(sql);
+    } catch (SQLException e) {
+        throw new ErrorQuery("Error al ejecutar la sentencia de escritura: " + e.getMessage(), e);
+    }
+  }
 }
+
+    


### PR DESCRIPTION
## ¿Qué hace este PR?

Este PR corrige la validación del método executeUpdate() en ConnectionProvider, asegurando que se rechacen explícitamente sentencias SQL de tipo SELECT.

Se reemplaza la validación indirecta basada en SqlValidator por una verificación directa del string SQL, mejorando claridad y cumpliendo con el requerimiento del issue.

## Issue relacionado
Closes #232

## Tipo de cambio
- [x] fix — corrección de error

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1853" height="751" alt="image" src="https://github.com/user-attachments/assets/5ba3c2a7-9983-4002-b0e3-4c338b2219b9" />
