### PR TITLE
chore: configurar Maven Shade Plugin para empaquetar JAR ejecutable #138

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>edu.sisinf</groupId>
     <artifactId>estante</artifactId>
     <version>0.1.0</version>
     <packaging>jar</packaging>
-
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
@@ -17,58 +14,49 @@
         <javafx.version>21.0.2</javafx.version>
         <junit.version>5.10.2</junit.version>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
             <version>${javafx.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
             <version>${javafx.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.46.0.0</version>
         </dependency>
-
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>8.3.0</version>
         </dependency>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.16.1</version>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>2.0.12</version>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.12</version>
             <scope>runtime</scope>
         </dependency>
-
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -76,7 +64,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -89,7 +76,6 @@
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
@@ -98,13 +84,34 @@
                     <mainClass>edu.sisinf.estante.App</mainClass>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded</shadedClassifierName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>edu.sisinf.estante.Launcher</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/src/main/java/edu/sisinf/estante/Launcher.java
+++ b/src/main/java/edu/sisinf/estante/Launcher.java
@@ -1,0 +1,20 @@
+package edu.sisinf.estante;
+
+/**
+ * Clase de entrada para el JAR ejecutable.
+ *
+ * JavaFX requiere una clase lanzadora que no extienda Application
+ * para que el JAR shaded funcione con java -jar sin argumentos
+ * adicionales de módulos JVM.
+ */
+public class Launcher {
+
+    /**
+     * Punto de entrada de la aplicación.
+     *
+     * @param args argumentos de línea de comandos
+     */
+    public static void main(String[] args) {
+        App.main(args);
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Configura el Maven Shade Plugin 3.5.1 en `pom.xml` para producir un JAR ejecutable con todas las dependencias incluidas (`estante-0.1.0-shaded.jar`). Crea `Launcher.java` como clase de entrada para que `java -jar` funcione sin argumentos JVM adicionales de módulos JavaFX.

## Issue relacionado
Closes #138

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/00a480de-6a03-452e-b60d-65c7d5a40d4d" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8c69da5b-7c4a-49ee-a036-4e934f40c736" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2f70d7be-9d65-48f3-8aa9-3c2a71f757e8" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b061baa1-1bb2-435f-9bdd-cd645ce1e0d5" />
