### PR TITLE
feat(servicio): implementar ExportadorJSON para exportar resultados a JSON #278

### DIFF
--- a/src/main/java/edu/sisinf/estante/servicio/ExportadorJSON.java
+++ b/src/main/java/edu/sisinf/estante/servicio/ExportadorJSON.java
@@ -1,0 +1,139 @@
+package edu.sisinf.estante.servicio;
+
+import edu.sisinf.estante.core.ErrorPersistencia;
+import edu.sisinf.estante.modelo.ResultadoQuery;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Servicio para exportar resultados de consultas a archivos JSON.
+ */
+public class ExportadorJSON {
+
+    /**
+     * Exporta un resultado de consulta a un archivo JSON.
+     *
+     * El archivo resultante contiene un array de objetos JSON,
+     * uno por cada fila del resultado. Si el archivo ya existe,
+     * se sobreescribe.
+     *
+     * @param resultado resultado de la consulta
+     * @param archivo   archivo destino
+     */
+    public void exportar(ResultadoQuery resultado, File archivo) {
+
+        if (resultado.getTipo() != ResultadoQuery.Tipo.LECTURA) {
+            throw new ErrorPersistencia(
+                    "Solo se pueden exportar resultados de lectura"
+            );
+        }
+
+        List<String> columnas = resultado.getColumnas();
+        List<List<Object>> filas = resultado.getFilas();
+
+        try (BufferedWriter writer =
+                     new BufferedWriter(
+                             new OutputStreamWriter(
+                                     new FileOutputStream(archivo),
+                                     StandardCharsets.UTF_8
+                             )
+                     )) {
+
+            writer.write("[");
+            writer.write("\n");
+
+            for (int f = 0; f < filas.size(); f++) {
+
+                List<Object> fila = filas.get(f);
+
+                writer.write("  {");
+                writer.write("\n");
+
+                for (int c = 0; c < columnas.size(); c++) {
+
+                    writer.write("    ");
+                    writer.write(escaparCadena(columnas.get(c)));
+                    writer.write(": ");
+                    writer.write(serializarValor(fila.get(c)));
+
+                    if (c < columnas.size() - 1) {
+                        writer.write(",");
+                    }
+
+                    writer.write("\n");
+                }
+
+                writer.write("  }");
+
+                if (f < filas.size() - 1) {
+                    writer.write(",");
+                }
+
+                writer.write("\n");
+            }
+
+            writer.write("]");
+            writer.write("\n");
+
+        } catch (IOException e) {
+            throw new ErrorPersistencia(
+                    "Error al exportar archivo JSON",
+                    e
+            );
+        }
+    }
+
+    /**
+     * Serializa un valor de celda al formato JSON correspondiente.
+     *
+     * @param valor valor de la celda
+     * @return representación JSON del valor
+     */
+    private String serializarValor(Object valor) {
+
+        if (valor == null) {
+            return "null";
+        }
+
+        if (valor instanceof Number) {
+            return valor.toString();
+        }
+
+        if (valor instanceof Boolean) {
+            return valor.toString();
+        }
+
+        return escaparCadena(valor.toString());
+    }
+
+    /**
+     * Escapa una cadena de texto para que sea válida en JSON.
+     *
+     * @param texto texto a escapar
+     * @return cadena entre comillas con caracteres especiales escapados
+     */
+    private String escaparCadena(String texto) {
+
+        StringBuilder sb = new StringBuilder("\"");
+
+        for (char c : texto.toCharArray()) {
+            switch (c) {
+                case '"'  -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default   -> sb.append(c);
+            }
+        }
+
+        sb.append("\"");
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa `ExportadorJSON`, un servicio que exporta resultados de consultas SQL a archivos JSON. Genera un array de objetos JSON con una entrada por fila. Maneja correctamente valores NULL, números, booleanos y cadenas con caracteres especiales. Sobreescribe el archivo si ya existe.

## Issue relacionado
Closes #278

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5de85f2a-1757-44c8-9c23-6102caedb6b3" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/10b5e230-793b-4771-948d-18b367ddaa53" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5660bc66-2f2b-43a4-9ab6-db83ebaf7341" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4e297967-a098-40a0-9303-7069e7db584f" />
