### PR TITLE
fix: corregir executeUpdate() para que rechace explícitamente sentencias SELECT #232

### DIFF
--- a/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
+++ b/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
@@ -109,8 +109,9 @@ public class ConnectionProvider {
      * @throws IllegalArgumentException si la sentencia es un SELECT
      * @throws ErrorQuery               si ocurre un error durante la ejecución SQL
      */
-    public static int executeUpdate(Connection connection, String sql) throws IllegalArgumentException, ErrorQuery {
-        
+   public static int executeUpdate(Connection connection, String sql)
+        throws IllegalArgumentException, ErrorQuery {
+
     if (sql == null || sql.trim().toUpperCase().startsWith("SELECT")) {
         throw new IllegalArgumentException(
                 "executeUpdate() no permite sentencias SELECT. Use executeSelect() para consultas."
@@ -120,7 +121,9 @@ public class ConnectionProvider {
     try (Statement statement = connection.createStatement()) {
         return statement.executeUpdate(sql);
     } catch (SQLException e) {
-        throw new ErrorQuery("Error al ejecutar la sentencia de escritura: " + e.getMessage(), e);
+        throw new ErrorQuery(
+                "Error al ejecutar la sentencia de escritura: " + e.getMessage(),
+                e
+        );
     }
-  }
 }

--- a/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
+++ b/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
@@ -109,12 +109,17 @@ public class ConnectionProvider {
      * @throws IllegalArgumentException si la sentencia es un SELECT
      * @throws ErrorQuery               si ocurre un error durante la ejecución SQL
      */
-   public static int executeUpdate(Connection connection, String sql)
+ public static int executeUpdate(Connection connection, String sql)
         throws IllegalArgumentException, ErrorQuery {
 
-    if (sql == null || sql.trim().toUpperCase().startsWith("SELECT")) {
+    if (sql == null) {
+        throw new IllegalArgumentException("La sentencia SQL no puede ser nula.");
+    }
+
+    if (sql.trim().toUpperCase().startsWith("SELECT")) {
         throw new IllegalArgumentException(
-                "executeUpdate() no permite sentencias SELECT. Use executeSelect() para consultas."
+                "executeUpdate() no permite sentencias SELECT de selección. " +
+                "Use executeSelect() para consultas. Sentencia rechazada: [" + sql + "]"
         );
     }
 
@@ -126,4 +131,4 @@ public class ConnectionProvider {
                 e
         );
     }
-}
+} 


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige el método executeUpdate() para rechazar explícitamente sentencias SELECT, lanzando una IllegalArgumentException con un mensaje descriptivo. Se mantiene sin cambios la ejecución de sentencias válidas de escritura (INSERT, UPDATE y DELETE).

executeUpdate("SELECT * FROM t") ahora lanza IllegalArgumentException.

El mensaje de error indica que executeUpdate() no permite sentencias SELECT y sugiere usar executeSelect().

Las sentencias de escritura continúan funcionando normalmente.

## Issue relacionado
Closes #232 

## Tipo de cambio

- [x] fix — corrección de error


## Checklist
- [X] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1782" height="786" alt="image" src="https://github.com/user-attachments/assets/d4272b36-3ab5-495a-b541-d0ead7f2a5f2" />
