### PR TITLE
feat(controller): agregar confirmacion antes de ejecutar DML

### DIFF
--- a/src/main/java/edu/sisinf/estante/controller/PanelEditorSQLController.java
+++ b/src/main/java/edu/sisinf/estante/controller/PanelEditorSQLController.java
@@ -1,5 +1,7 @@
 package edu.sisinf.estante.controller;
 
+import edu.sisinf.estante.util.SqlValidator;
+
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -77,9 +79,24 @@ public class PanelEditorSQLController {
      * Dispara el callback si el texto no está vacío.
      */
     private void disparar() {
-        String texto = areaSQL.getText();
-        if (onEjecutar != null && !texto.isBlank()) {
-            onEjecutar.accept(texto);
+
+    String texto = areaSQL.getText();
+
+    if (texto.isBlank() || onEjecutar == null) {
+        return;
+    }
+
+    if (SqlValidator.esDestructiva(texto)) {
+
+        boolean confirmar =
+                DialogoConfirmacionDML.confirmar(texto);
+
+        if (!confirmar) {
+            return;
         }
     }
+
+    onEjecutar.accept(texto);
+}
+
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega una confirmación previa antes de ejecutar consultas SQL destructivas (DML) desde el editor SQL.
Cuando el usuario intenta ejecutar una sentencia DML, se muestra un diálogo de confirmación. 
Si el usuario cancela, la consulta no se ejecuta; si confirma, la ejecución continúa normalmente
## Issue relacionado
Closes #283

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas