### PR TITLE
feat(dao): implementar soporte PostgreSQL — ConexionDAOPostgreSQL #277

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -34,6 +34,11 @@
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>8.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/edu/sisinf/estante/dao/ConexionDAOPostgreSQL.java
+++ b/src/main/java/edu/sisinf/estante/dao/ConexionDAOPostgreSQL.java
@@ -1,0 +1,89 @@
+package edu.sisinf.estante.dao;
+
+import edu.sisinf.estante.modelo.Conexion;
+import edu.sisinf.estante.modelo.TipoMotor;
+import edu.sisinf.estante.core.ErrorConexion;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+/**
+ * Implementación concreta de {@link IConexionDAO} para PostgreSQL.
+ * PostgreSQL requiere host, puerto, usuario y password para conectarse.
+ * La clase es stateless: no almacena conexiones internamente
+ * y no implementa pooling de conexiones.
+ */
+public class ConexionDAOPostgreSQL implements IConexionDAO {
+
+    private static final String PUERTO_DEFAULT = "5432";
+
+    /**
+     * Devuelve el motor de base de datos que maneja esta implementación.
+     *
+     * @return {@link TipoMotor#POSTGRESQL}
+     */
+    @Override
+    public TipoMotor motor() {
+        return TipoMotor.POSTGRESQL;
+    }
+
+    /**
+     * Construye la URL JDBC para PostgreSQL con el formato
+     * {@code jdbc:postgresql://<host>:<puerto>/<basedatos>}.
+     * Si el puerto es {@code null}, se usa {@code 5432} por defecto.
+     *
+     * @param conexion Objeto con los datos de conexión.
+     * @return URL JDBC para PostgreSQL.
+     */
+    @Override
+    public String construirUrl(Conexion conexion) {
+        String puerto = (conexion.getPuerto() != null)
+                ? conexion.getPuerto().toString()
+                : PUERTO_DEFAULT;
+        return String.format("jdbc:postgresql://%s:%s/%s",
+                conexion.getHost(),
+                puerto,
+                conexion.getBasedatos());
+    }
+
+    /**
+     * Abre una conexión a la base de datos PostgreSQL.
+     *
+     * @param conexion Objeto con los datos de conexión.
+     * @return Conexión JDBC activa.
+     * @throws ErrorConexion si el motor no es PostgreSQL o faltan campos obligatorios.
+     * @throws SQLException  si el driver falla al conectar.
+     */
+    @Override
+    public Connection abrir(Conexion conexion) throws ErrorConexion, SQLException {
+        if (conexion.getTipoMotor() != TipoMotor.POSTGRESQL) {
+            throw new ErrorConexion("El motor de la conexión no es PostgreSQL.");
+        }
+        if (conexion.getHost() == null || conexion.getHost().isBlank()) {
+            throw new ErrorConexion("El host no puede estar vacío.");
+        }
+        if (conexion.getBasedatos() == null || conexion.getBasedatos().isBlank()) {
+            throw new ErrorConexion("El nombre de la base de datos no puede estar vacío.");
+        }
+        String url = construirUrl(conexion);
+        return DriverManager.getConnection(url,
+                conexion.getUsuario(),
+                conexion.getPassword());
+    }
+
+    /**
+     * Prueba si la conexión a la base de datos PostgreSQL es válida.
+     *
+     * @param conexion Objeto con los datos de conexión.
+     * @return {@code true} si la conexión es válida, {@code false} en caso contrario.
+     */
+    @Override
+    public boolean probar(Conexion conexion) {
+        try (Connection conn = abrir(conexion)) {
+            return conn.isValid(3);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/edu/sisinf/estante/modelo/TipoMotor.java
+++ b/src/main/java/edu/sisinf/estante/modelo/TipoMotor.java
@@ -2,5 +2,6 @@ package edu.sisinf.estante.modelo;
 
 public enum TipoMotor {
     SQLITE,
-    MYSQL
+    MYSQL,
+    POSTGRESQL
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa `ConexionDAOPostgreSQL` siguiendo el mismo patrón que `ConexionDAOMySQL`. Agrega `POSTGRESQL` al enum `TipoMotor`. Agrega el driver `org.postgresql:postgresql:42.7.0` al `pom.xml`. La URL de conexión usa el formato `jdbc:postgresql://host:puerto/basedatos` con puerto por defecto 5432.

## Issue relacionado
Closes #277

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e21ec885-5342-48a4-92bf-37a113ae0819" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/69bca9e1-043b-4f02-8fa1-aedf6db7e1e2" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dccfc9bb-add7-4465-a906-810c17f5239f" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/103403ae-a3af-4b52-8df2-8e1dc054f6aa" />

