### PR TITLE
feat(controller): implementar PanelHistorialController con vista FXML #280

### DIFF
--- a/src/main/java/edu/sisinf/estante/controller/PanelHistorialController.java
+++ b/src/main/java/edu/sisinf/estante/controller/PanelHistorialController.java
@@ -1,0 +1,112 @@
+package edu.sisinf.estante.controller;
+
+import edu.sisinf.estante.modelo.EntradaHistorial;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Controller del panel de historial de queries de Estante.
+ *
+ * <p>Muestra las últimas queries ejecutadas en la sesión en un ListView.
+ * Expone hooks para que la integración reaccione al doble clic sobre
+ * una entrada y al botón de limpiar historial.</p>
+ *
+ * <p>Archivos relacionados:</p>
+ * <ul>
+ *   <li>Vista: {@code src/main/resources/edu/sisinf/estante/fxml/PanelHistorial.fxml}</li>
+ * </ul>
+ */
+public class PanelHistorialController {
+
+    private static final int MAX_QUERY_CHARS = 60;
+    private static final DateTimeFormatter FORMATO =
+            DateTimeFormatter.ofPattern("HH:mm:ss");
+
+    @FXML private ListView<EntradaHistorial> listaHistorial;
+    @FXML private Button btnLimpiar;
+
+    private Consumer<String> onQuerySeleccionada = null;
+
+    /**
+     * Inicializa el ListView con celda personalizada y registra
+     * el manejador de doble clic.
+     */
+    @FXML
+    public void initialize() {
+        listaHistorial.setCellFactory(lv -> new ListCell<>() {
+            @Override
+            protected void updateItem(EntradaHistorial entrada, boolean empty) {
+                super.updateItem(entrada, empty);
+                if (empty || entrada == null) {
+                    setText(null);
+                } else {
+                    String hora = LocalDateTime
+                            .ofInstant(
+                                    Instant.ofEpochMilli(entrada.timestamp()),
+                                    ZoneId.systemDefault()
+                            )
+                            .format(FORMATO);
+                    String query = entrada.query().length() > MAX_QUERY_CHARS
+                            ? entrada.query().substring(0, MAX_QUERY_CHARS) + "..."
+                            : entrada.query();
+                    setText("[" + hora + "] " + query);
+                }
+            }
+        });
+
+        listaHistorial.setOnMouseClicked(event -> {
+            if (event.getClickCount() == 2) {
+                EntradaHistorial seleccionada =
+                        listaHistorial.getSelectionModel().getSelectedItem();
+                if (seleccionada != null && onQuerySeleccionada != null) {
+                    onQuerySeleccionada.accept(seleccionada.query());
+                }
+            }
+        });
+    }
+
+    /**
+     * Carga la lista de entradas del historial en el ListView.
+     *
+     * @param entradas lista de entradas a mostrar
+     */
+    public void cargarHistorial(List<EntradaHistorial> entradas) {
+        listaHistorial.getItems().setAll(entradas);
+    }
+
+    /**
+     * Vacía visualmente el ListView del historial.
+     */
+    @FXML
+    public void limpiarHistorial() {
+        listaHistorial.getItems().clear();
+    }
+
+    /**
+     * Registra el callback invocado cuando el usuario hace doble clic
+     * sobre una entrada del historial.
+     *
+     * @param callback Consumer que recibe la query seleccionada
+     */
+    public void setOnQuerySeleccionada(Consumer<String> callback) {
+        this.onQuerySeleccionada = callback;
+    }
+
+    /**
+     * Devuelve el botón "Limpiar historial".
+     *
+     * @return botón de limpiar
+     */
+    public Button getBotonLimpiar() {
+        return btnLimpiar;
+    }
+}

--- a/src/main/resources/edu/sisinf/estante/fxml/PanelHistorial.fxml
+++ b/src/main/resources/edu/sisinf/estante/fxml/PanelHistorial.fxml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.geometry.Insets?>
+
+<VBox xmlns="http://javafx.com/javafx"
+      xmlns:fx="http://javafx.com/fxml"
+      fx:controller="edu.sisinf.estante.controller.PanelHistorialController"
+      spacing="8"
+      stylesheets="@../css/estante.css">
+
+    <padding>
+        <Insets top="8" right="8" bottom="8" left="8"/>
+    </padding>
+
+    <HBox spacing="8" alignment="CENTER_LEFT">
+        <Label text="Historial de queries" style="-fx-font-weight: bold;"/>
+        <Button fx:id="btnLimpiar"
+                text="Limpiar"
+                onAction="#limpiarHistorial"
+                styleClass="button-secundario"/>
+    </HBox>
+
+    <ListView fx:id="listaHistorial"
+              VBox.vgrow="ALWAYS"/>
+
+</VBox>


### PR DESCRIPTION
… #280

## ¿Qué hace este PR?
Implementa `PanelHistorialController` con un ListView que muestra las queries recientes con timestamp y query truncada a 60 caracteres. Doble clic en una entrada activa un callback que puede conectarse al editor SQL. Implementa botón "Limpiar" para vaciar el historial. Crea el FXML correspondiente `PanelHistorial.fxml`.

## Issue relacionado
Closes #280

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/79b6b1ea-0ae7-448c-865a-2a7b2d70b787" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bef4fc7b-90b2-4c79-a86a-5eaa73a9969b" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0ff469d7-75d1-4fb9-831d-08bc7806d250" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/227f2e8d-c201-4017-8c62-97c80bdbe7b7" />
