### PR TITLE
feat(dao): implementar soporte para conexión con SSL en ConexionDAOMySQL #300

### DIFF
--- a/src/main/java/edu/sisinf/estante/controller/DialogoNuevaConexionController.java
+++ b/src/main/java/edu/sisinf/estante/controller/DialogoNuevaConexionController.java
@@ -1,20 +1,16 @@
-// ============================================================
-// ARCHIVO 2: DialogoNuevaConexionController.java
-// RUTA: src/main/java/edu/sisinf/estante/controller/DialogoNuevaConexionController.java
-// ============================================================
- 
 package edu.sisinf.estante.controller;
- 
+
 import edu.sisinf.estante.modelo.Conexion;
 import edu.sisinf.estante.modelo.TipoMotor;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
 import javafx.stage.Stage;
- 
+
 /**
  * Controller del diálogo modal para crear una nueva conexión.
  *
@@ -26,37 +22,38 @@ import javafx.stage.Stage;
  * del controller para mantener bajo el acoplamiento con los servicios.</p>
  */
 public class DialogoNuevaConexionController {
- 
+
     // --------------------------------------------------------
     // FXML fields
     // --------------------------------------------------------
- 
-    @FXML private TextField     campoNombre;
+
+    @FXML private TextField           campoNombre;
     @FXML private ComboBox<TipoMotor> comboMotor;
-    @FXML private TextField     campoHost;
-    @FXML private TextField     campoPuerto;
-    @FXML private TextField     campoBaseDatos;
-    @FXML private TextField     campoUsuario;
-    @FXML private PasswordField campoPassword;
-    @FXML private Label         etiquetaEstado;
-    @FXML private Button        botonProbar;
-    @FXML private Button        botonGuardar;
-    @FXML private Button        botonCancelar;
- 
+    @FXML private TextField           campoHost;
+    @FXML private TextField           campoPuerto;
+    @FXML private TextField           campoBaseDatos;
+    @FXML private TextField           campoUsuario;
+    @FXML private PasswordField       campoPassword;
+    @FXML private CheckBox            checkBoxSSL;
+    @FXML private Label               etiquetaEstado;
+    @FXML private Button              botonProbar;
+    @FXML private Button              botonGuardar;
+    @FXML private Button              botonCancelar;
+
     /** Resultado del diálogo. Es null si el usuario canceló. */
     private Conexion conexionResultado;
- 
+
     // --------------------------------------------------------
     // Initialization
     // --------------------------------------------------------
- 
+
     /**
      * Inicializa el diálogo:
      * <ul>
-     *   <li>Llena el ComboBox con los valores de {@link TipoMotor}.</li>
-     *   <li>Selecciona SQLITE por defecto y deshabilita los campos que no aplican.</li>
-     *   <li>Registra el listener del ComboBox para habilitar/deshabilitar campos.</li>
-     *   <li>Conecta el botón "Cancelar" para cerrar el diálogo.</li>
+     * <li>Llena el ComboBox con los valores de {@link TipoMotor}.</li>
+     * <li>Selecciona SQLITE por defecto y deshabilita los campos que no aplican.</li>
+     * <li>Registra el listener del ComboBox para habilitar/deshabilitar campos.</li>
+     * <li>Conecta el botón "Cancelar" para cerrar el diálogo.</li>
      * </ul>
      */
     @FXML
@@ -64,21 +61,21 @@ public class DialogoNuevaConexionController {
         comboMotor.getItems().addAll(TipoMotor.values());
         comboMotor.setValue(TipoMotor.SQLITE);
         actualizarCamposSegunMotor(TipoMotor.SQLITE);
- 
+
         comboMotor.valueProperty().addListener(
                 (observable, oldValue, newValue) -> actualizarCamposSegunMotor(newValue)
         );
- 
+
         botonCancelar.setOnAction(event -> cerrar());
     }
- 
+
     // --------------------------------------------------------
     // Private helpers
     // --------------------------------------------------------
- 
+
     /**
      * Habilita o deshabilita los campos de red según el motor seleccionado.
-     * SQLite no requiere host, puerto, usuario ni password.
+     * SQLite no requiere host, puerto, usuario, password ni SSL.
      *
      * @param motor motor seleccionado en el ComboBox
      */
@@ -88,8 +85,9 @@ public class DialogoNuevaConexionController {
         campoPuerto.setDisable(esSqlite);
         campoUsuario.setDisable(esSqlite);
         campoPassword.setDisable(esSqlite);
+        checkBoxSSL.setDisable(esSqlite);
     }
- 
+
     /**
      * Cierra el diálogo sin guardar.
      * El resultado queda como {@code null}.
@@ -97,18 +95,18 @@ public class DialogoNuevaConexionController {
     private void cerrar() {
         ((Stage) botonCancelar.getScene().getWindow()).close();
     }
- 
+
     // --------------------------------------------------------
     // Public API
     // --------------------------------------------------------
- 
+
     /**
      * Construye un objeto {@link Conexion} con los valores actuales del formulario.
      *
      * <ul>
-     *   <li>Si el campo "Puerto" está vacío, el puerto del objeto será {@code null}.</li>
-     *   <li>Si el campo "Puerto" contiene un valor no numérico, el puerto será {@code null}.</li>
-     *   <li>Los demás campos se copian directamente desde los controles.</li>
+     * <li>Si el campo "Puerto" está vacío, el puerto del objeto será {@code null}.</li>
+     * <li>Si el campo "Puerto" contiene un valor no numérico, el puerto será {@code null}.</li>
+     * <li>Los demás campos se copian directamente desde los controles.</li>
      * </ul>
      *
      * @return objeto {@link Conexion} armado con los datos del formulario
@@ -121,7 +119,8 @@ public class DialogoNuevaConexionController {
         conexion.setBasedatos(campoBaseDatos.getText());
         conexion.setUsuario(campoUsuario.getText());
         conexion.setPassword(campoPassword.getText());
- 
+        conexion.setUsarSSL(checkBoxSSL.isSelected());
+
         String puertoTexto = campoPuerto.getText();
         if (puertoTexto != null && !puertoTexto.isBlank()) {
             try {
@@ -132,10 +131,10 @@ public class DialogoNuevaConexionController {
         } else {
             conexion.setPuerto(null);
         }
- 
+
         return conexion;
     }
- 
+
     /**
      * Devuelve la conexión resultado del diálogo.
      * Es {@code null} si el usuario canceló sin guardar.
@@ -145,7 +144,7 @@ public class DialogoNuevaConexionController {
     public Conexion getConexionResultado() {
         return conexionResultado;
     }
- 
+
     /**
      * Establece la conexión resultado del diálogo.
      * La integración llama a este método tras validar y persistir la conexión.
@@ -155,7 +154,7 @@ public class DialogoNuevaConexionController {
     public void setConexionResultado(Conexion conexion) {
         this.conexionResultado = conexion;
     }
- 
+
     /**
      * Devuelve el botón "Probar" para que la integración le conecte su handler.
      *
@@ -164,7 +163,7 @@ public class DialogoNuevaConexionController {
     public Button getBotonProbar() {
         return botonProbar;
     }
- 
+
     /**
      * Devuelve el botón "Guardar" para que la integración le conecte su handler.
      *
@@ -173,7 +172,7 @@ public class DialogoNuevaConexionController {
     public Button getBotonGuardar() {
         return botonGuardar;
     }
- 
+
     /**
      * Devuelve la etiqueta de estado para que la integración muestre mensajes al usuario.
      *

--- a/src/main/java/edu/sisinf/estante/dao/ConexionDAOMySQL.java
+++ b/src/main/java/edu/sisinf/estante/dao/ConexionDAOMySQL.java
@@ -10,30 +10,25 @@ import java.sql.SQLException;
 
 /**
  * Implementación concreta de {@link IConexionDAO} para MySQL.
- * MySQL requiere host, puerto, usuario y password para conectarse.
- * La clase es stateless: no almacena conexiones internamente
- * y no implementa pooling de conexiones.
  */
 public class ConexionDAOMySQL implements IConexionDAO {
 
     private static final String PUERTO_DEFAULT = "3306";
-    private static final String PARAMS =
-            "useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true";
+    private static final String PARAMS_BASE =
+            "serverTimezone=UTC&allowPublicKeyRetrieval=true";
+    private static final String PARAMS_SIN_SSL =
+            "useSSL=false&" + PARAMS_BASE;
+    private static final String PARAMS_CON_SSL =
+            "useSSL=true&requireSSL=true&" + PARAMS_BASE;
 
-    /**
-     * Devuelve el motor de base de datos que maneja esta implementación.
-     *
-     * @return {@link TipoMotor#MYSQL}
-     */
     @Override
     public TipoMotor motor() {
         return TipoMotor.MYSQL;
     }
 
     /**
-     * Construye la URL JDBC para MySQL con el formato
-     * {@code jdbc:mysql://<host>:<puerto>/<basedatos>?<parametros>}.
-     * Si el puerto es {@code null}, se usa {@code 3306} por defecto.
+     * Construye la URL JDBC para MySQL.
+     * Si usarSSL es true, incluye useSSL=true&requireSSL=true.
      *
      * @param conexion Objeto con los datos de conexión.
      * @return URL JDBC para MySQL.
@@ -44,48 +39,33 @@ public class ConexionDAOMySQL implements IConexionDAO {
                 ? conexion.getPuerto().toString()
                 : PUERTO_DEFAULT;
 
+        String params = conexion.isUsarSSL() ? PARAMS_CON_SSL : PARAMS_SIN_SSL;
+
         return String.format("jdbc:mysql://%s:%s/%s?%s",
                 conexion.getHost(),
                 puerto,
-                conexion.getBasedatos(),
-                PARAMS);
+                conexion.getBaseDatos(),
+                params);
     }
 
-    /**
-     * Abre una conexión a la base de datos MySQL.
-     *
-     * @param conexion Objeto con los datos de conexión.
-     * @return Conexión JDBC activa.
-     * @throws ErrorConexion si el motor no es MySQL o faltan campos obligatorios.
-     * @throws SQLException  si el driver falla al conectar.
-     */
     @Override
     public Connection abrir(Conexion conexion) throws ErrorConexion, SQLException {
-
         if (conexion.getTipoMotor() != TipoMotor.MYSQL) {
             throw new ErrorConexion("El motor de la conexión no es MySQL.");
         }
-
         if (conexion.getHost() == null || conexion.getHost().isBlank()) {
             throw new ErrorConexion("El host no puede estar vacío.");
         }
-
-        if (conexion.getBasedatos() == null || conexion.getBasedatos().isBlank()) {
+        if (conexion.getBaseDatos() == null || conexion.getBaseDatos().isBlank()) {
             throw new ErrorConexion("El nombre de la base de datos no puede estar vacío.");
         }
 
         String url = construirUrl(conexion);
         return DriverManager.getConnection(url,
                 conexion.getUsuario(),
-                conexion.getPassword());
+                conexion.getContrasena());
     }
 
-    /**
-     * Prueba si la conexión a la base de datos MySQL es válida.
-     *
-     * @param conexion Objeto con los datos de conexión.
-     * @return {@code true} si la conexión es válida, {@code false} en caso contrario.
-     */
     @Override
     public boolean probar(Conexion conexion) {
         try (Connection conn = abrir(conexion)) {

--- a/src/main/java/edu/sisinf/estante/modelo/Conexion.java
+++ b/src/main/java/edu/sisinf/estante/modelo/Conexion.java
@@ -21,7 +21,6 @@ public class Conexion {
 
     /**
      * Lista de etiquetas para organizar conexiones por categoría.
-     * Ejemplos: "produccion", "desarrollo", "local", "cliente-X".
      * Por defecto es una lista vacía para compatibilidad con versiones anteriores.
      */
     private List<String> etiquetas = new ArrayList<>();
@@ -32,15 +31,14 @@ public class Conexion {
 
     public Conexion(String nombre, String host, Integer puerto,
                     String basedatos, String usuario, String password) {
-        this.nombre   = nombre;
-        this.host     = host;
-        this.puerto   = puerto;
+        this.nombre    = nombre;
+        this.host      = host;
+        this.puerto    = puerto;
         this.basedatos = basedatos;
-        this.usuario  = usuario;
-        this.password = password;
+        this.usuario   = usuario;
+        this.password  = password;
     }
 
-    // Getters y Setters
     public String getId()                  { return id; }
     public void setId(String id)           { this.id = id; }
 
@@ -65,6 +63,10 @@ public class Conexion {
     public TipoMotor getTipoMotor()             { return tipoMotor; }
     public void setTipoMotor(TipoMotor motor)   { this.tipoMotor = motor; }
 
+    /**
+     * Indica si la conexión debe usar SSL/TLS.
+     * @return true si SSL está habilitado, false por defecto.
+     */
     public boolean isUsarSSL()             { return usarSSL; }
     public void setUsarSSL(boolean ssl)    { this.usarSSL = ssl; }
 


### PR DESCRIPTION

## ¿Qué hace este PR?
Agrega campo usarSSL (default false) a Conexion.java.
Modifica construirUrl() en ConexionDAOMySQL para incluir
useSSL=true&requireSSL=true cuando usarSSL es true.
Agrega checkbox SSL en DialogoNuevaConexionController.
Conexiones guardadas sin usarSSL son compatibles por default false.


## Issue relacionado
Closes #300

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica