### PR TITLE
fix: corregir ConnectionProvider.java para que la clase esté en el paquete core correcto  #237

### DIFF
--- a/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
+++ b/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
@@ -3,6 +3,7 @@ package edu.sisinf.estante.core;
 import edu.sisinf.estante.config.DBConfig;
 import edu.sisinf.estante.dto.QueryResult;
 import edu.sisinf.estante.util.SqlValidator;
+import edu.sisinf.estante.core.ErrorQuery;
 
 import java.sql.Connection;
 import java.sql.DriverManager;


### PR DESCRIPTION
## ¿Qué hace este PR?

Verifica y corrige la declaración de paquete de ConnectionProvider.java para asegurar que coincide con su ubicación física dentro de src/main/java/edu/sisinf/estante/core/.

También se revisan los imports utilizados por la clase para confirmar que apuntan a los paquetes correctos y no existen discrepancias que provoquen errores de compilación relacionados con paquetes.

## Issue relacionado
Closes #237 

## Tipo de cambio

- [x] fix — corrección de error

## Checklist
- [ ] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1130" height="140" alt="image" src="https://github.com/user-attachments/assets/5f4edb9b-f8dc-4bf0-8ffb-50d8a5d84c68" />
<img width="1352" height="528" alt="image" src="https://github.com/user-attachments/assets/2fd60235-f35d-43a1-8c06-dd8ad4fd4d5f" />
