### PR TITLE
docs(readme): agregar sección Inicio Rápido

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 # Estante
+## Inicio Rápido
+
+```bash
+git clone https://github.com/sis-inf/estante.git
+mvn compile
+mvn javafx:run
+```
+
+Al ejecutar `mvn javafx:run` se abrirá la ventana principal de la aplicación Estante con su interfaz gráfica JavaFX.
 
 Gestor de base de datos con interfaz gráfica desarrollado en Java y JavaFX.
 
@@ -55,5 +64,4 @@ Ver [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Licencia
 MIT — ver [LICENSE](LICENSE)
-## ✨ Cambio final
-README actualizado correctamente.
+


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega una sección Inicio Rápido al inicio del README.md con los comandos básicos para clonar, compilar y ejecutar la aplicación usando Maven. También se menciona que mvn javafx:run abre la ventana principal de Estante.

## Issue relacionado
Closes #395 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas