### PR TITLE
feat(servicio): implementar ValidadorSQL para verificacion previa de …

### DIFF
--- a/src/main/java/edu/sisinf/estante/servicio/ValidadorSQL.java
+++ b/src/main/java/edu/sisinf/estante/servicio/ValidadorSQL.java
@@ -1,0 +1,68 @@
+package edu.sisinf.estante.servicio;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Servicio encargado de validar la sintaxis basica y los permisos de consultas
+ * SQL antes de su ejecucion en el servidor.
+ */
+public class ValidadorSQL {
+
+  private static final Pattern SELECT_PURO_PATTERN =
+      Pattern.compile("^\\s*(SELECT|WITH)\\b", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern DML_PATTERN = Pattern.compile(
+      "\\b(INSERT|UPDATE|DELETE|DROP|TRUNCATE)\\b", Pattern.CASE_INSENSITIVE);
+
+  private static final Pattern SELECT_SINTAXIS_PATTERN = Pattern.compile(
+      "^\\s*SELECT\\s+.+\\s+FROM\\s+.+", Pattern.CASE_INSENSITIVE);
+
+  /**
+   * Verifica si la consulta es unicamente de lectura.
+   */
+  public boolean esSelectPuro(String sql) {
+    if (sql == null || sql.isBlank()) {
+      return false;
+    }
+    return SELECT_PURO_PATTERN.matcher(sql).find();
+  }
+
+  /**
+   * Detecta si la consulta contiene comandos que alteran o eliminan datos.
+   */
+  public boolean contieneDML(String sql) {
+    if (sql == null || sql.isBlank()) {
+      return false;
+    }
+    return DML_PATTERN.matcher(sql).find();
+  }
+
+  /**
+   * Realiza un analisis de sintaxis basica sobre la consulta.
+   */
+  public List<String> validar(String sql) {
+    List<String> errores = new ArrayList<>();
+
+    if (sql == null || sql.isBlank()) {
+      errores.add("La consulta SQL no puede estar vacia.");
+      return errores;
+    }
+
+    String sqlTrimmed = sql.trim();
+
+    if (sqlTrimmed.toUpperCase().startsWith("SELECT")) {
+      if (!SELECT_SINTAXIS_PATTERN.matcher(sqlTrimmed).find()) {
+        errores.add("Error de sintaxis: Estructura SELECT incompleta.");
+      }
+    }
+
+    if (contieneDML(sqlTrimmed)) {
+      errores.add(
+          "Seguridad: No se permiten operaciones DML en este contexto.");
+    }
+
+    return errores;
+  }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa la clase de servicio `ValidadorSQL` para interceptar, analizar y validar de forma básica las estructuras de las consultas SQL antes de que sean enviadas al servidor de bases de datos. 

El servicio cuenta con lógica optimizada mediante expresiones regulares para verificar de forma aislada e independiente si una query corresponde estrictamente a un comando de lectura (`SELECT` o `WITH`), si contiene operaciones de manipulación o destrucción de datos restringidas (`INSERT`, `UPDATE`, `DELETE`, `DROP`, `TRUNCATE`), o si presenta anomalías estructurales de sintaxis básicas.

## Issue relacionado
Closes #282

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se ejecutó la compilación manual y aislada del archivo utilizando `javac`, completando el proceso con éxito y sin registrar ninguna advertencia o error en la consola de Git Bash.
<img width="681" height="166" alt="image" src="https://github.com/user-attachments/assets/f0072fb5-6253-4ae1-b6d8-f30751905087" />
