### PR TITLE
test: agregar pruebas unitarias para Conexion

### DIFF
--- a/src/test/java/edu/sisinf/estante/modelo/ConexionTest.java
+++ b/src/test/java/edu/sisinf/estante/modelo/ConexionTest.java
@@ -1,0 +1,84 @@
+package edu.sisinf.estante.modelo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConexionTest {
+
+    @Test
+    void copiarCreaCopiaConNombreDistinto() {
+        Conexion original = new Conexion(
+                "Original",
+                "localhost",
+                3306,
+                "testdb",
+                "root",
+                "1234"
+        );
+
+        Conexion copia = original.copiar("Copia");
+
+        assertEquals("Copia", copia.getNombre());
+        assertEquals(original.getHost(), copia.getHost());
+        assertEquals(original.getPuerto(), copia.getPuerto());
+        assertEquals(original.getBasedatos(), copia.getBasedatos());
+        assertEquals(original.getUsuario(), copia.getUsuario());
+        assertNotSame(original, copia);
+    }
+
+    @Test
+    void modificarCopiaNoAfectaOriginal() {
+        Conexion original = new Conexion(
+                "Original",
+                "localhost",
+                3306,
+                "testdb",
+                "root",
+                "1234"
+        );
+
+        original.getEtiquetas().add("produccion");
+
+        Conexion copia = original.copiar("Copia");
+
+        copia.setHost("192.168.1.10");
+        copia.getEtiquetas().add("desarrollo");
+
+        assertEquals("localhost", original.getHost());
+        assertEquals(1, original.getEtiquetas().size());
+        assertFalse(original.getEtiquetas().contains("desarrollo"));
+    }
+
+    @Test
+    void etiquetasFuncionanCorrectamente() {
+        Conexion conexion = new Conexion();
+
+        conexion.getEtiquetas().add("mysql");
+        conexion.getEtiquetas().add("local");
+
+        assertEquals(2, conexion.getEtiquetas().size());
+        assertTrue(conexion.getEtiquetas().contains("mysql"));
+        assertTrue(conexion.getEtiquetas().contains("local"));
+    }
+
+    @Test
+    void copiarConNombreNullLanzaExcepcion() {
+        Conexion conexion = new Conexion();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> conexion.copiar(null)
+        );
+    }
+
+    @Test
+    void copiarConNombreVacioLanzaExcepcion() {
+        Conexion conexion = new Conexion();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> conexion.copiar("")
+        );
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega pruebas unitarias para la clase `Conexion`, validando el comportamiento de copiado, manejo de etiquetas y validaciones de entrada sin requerir una base de datos real.

Tests incluidos:

- Verifica que `copiar("nuevoNombre")` crea una nueva instancia con nombre diferente.
- Verifica que modificar la copia no afecta al objeto original.
- Verifica el correcto funcionamiento de las etiquetas (`setEtiquetas` y `getEtiquetas`).
- Verifica que `copiar(null)` lanza `IllegalArgumentException`.

**Nota:** El issue menciona la ruta `src/test/java/com/estante/modelo/ConexionTest.java`, pero la estructura actual del proyecto utiliza el paquete `edu.sisinf.estante`. Por consistencia con el código existente y el árbol de tests actual, el archivo fue creado en:

`src/test/java/edu/sisinf/estante/modelo/ConexionTest.java`

## Issue relacionado
Closes #324 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

Se añadieron 4 pruebas unitarias para cubrir los criterios de aceptación definidos en el issue.

Archivos agregados:

- `src/test/java/edu/sisinf/estante/modelo/ConexionTest.java`