### PR TITLE
feat: agregar inspeccion de columnas

### DIFF
--- a/src/main/java/edu/sisinf/estante/modelo/ColumnaInfo.java
+++ b/src/main/java/edu/sisinf/estante/modelo/ColumnaInfo.java
@@ -1,0 +1,9 @@
+package edu.sisinf.estante.modelo;
+
+public record ColumnaInfo(
+        String nombre,
+        String tipoSQL,
+        boolean nullable,
+        Integer tamano,      //"tamaño"
+        String valorDefault
+) {}

--- a/src/main/java/edu/sisinf/estante/servicio/ExploradorEsquemas.java
+++ b/src/main/java/edu/sisinf/estante/servicio/ExploradorEsquemas.java
@@ -95,3 +95,30 @@ public class ExploradorEsquemas {
         return columnas;
     }
 }
+/**
+ * Obtiene las columnas de una tabla específica con nombre, tipo, nullable, tamaño y valor por defecto.
+ */
+public List<ColumnaInfo> getColumnas(Connection conexion, String tabla) {
+    List<ColumnaInfo> columnas = new ArrayList<>();
+    try {
+        DatabaseMetaData meta = conexion.getMetaData();
+
+        try (ResultSet rs = meta.getColumns(null, null, tabla, null)) {
+            while (rs.next()) {
+                String nombre = rs.getString("COLUMN_NAME");
+                String tipoSQL = rs.getString("TYPE_NAME");
+                boolean nullable = "YES".equals(rs.getString("IS_NULLABLE"));
+                Integer tamano = rs.getInt("COLUMN_SIZE");
+                if (rs.wasNull()) {
+                    tamano = null;
+                }
+                String valorDefault = rs.getString("COLUMN_DEF");
+
+                columnas.add(new ColumnaInfo(nombre, tipoSQL, nullable, tamano, valorDefault));
+            }
+        }
+    } catch (SQLException e) {
+        throw new RuntimeException("Error obteniendo columnas de la tabla " + tabla, e);
+    }
+    return columnas;
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega la funcionalidad de inspección de columnas de una tabla usando JDBC en ExploradorEsquemas.
Crea un record ColumnaInfo que contiene nombre, tipoSQL, nullable, tamano y valorDefault.
Permite obtener la lista de columnas de cualquier tabla con toda esta información

## Issue relacionado
Closes #288 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas