### PR TITLE
feat(servicio): implementar HistorialQuerys con registro de últimas 50 queries #279

### DIFF
--- a/src/main/java/edu/sisinf/estante/modelo/EntradaHistorial.java
+++ b/src/main/java/edu/sisinf/estante/modelo/EntradaHistorial.java
@@ -1,0 +1,18 @@
+package edu.sisinf.estante.modelo;
+
+/**
+ * Registro de una query ejecutada en la sesión.
+ *
+ * @param timestamp   momento en que se ejecutó la query (Unix ms)
+ * @param query       sentencia SQL ejecutada
+ * @param baseDatos   nombre de la base de datos o conexión activa
+ * @param duracionMs  tiempo de ejecución en milisegundos
+ * @param exitosa     indica si la query se ejecutó sin errores
+ */
+public record EntradaHistorial(
+        long timestamp,
+        String query,
+        String baseDatos,
+        long duracionMs,
+        boolean exitosa
+) {}

--- a/src/main/java/edu/sisinf/estante/servicio/HistorialQuerys.java
+++ b/src/main/java/edu/sisinf/estante/servicio/HistorialQuerys.java
@@ -1,0 +1,78 @@
+package edu.sisinf.estante.servicio;
+
+import edu.sisinf.estante.modelo.EntradaHistorial;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Servicio que mantiene un registro de las últimas 50 queries ejecutadas.
+ *
+ * Usa política FIFO: cuando se supera el límite, la entrada más antigua
+ * es descartada automáticamente.
+ */
+public class HistorialQuerys {
+
+    private static final int LIMITE = 50;
+
+    private final Deque<EntradaHistorial> historial = new ArrayDeque<>();
+
+    /**
+     * Agrega una nueva entrada al historial marcada como exitosa.
+     *
+     * @param query      sentencia SQL ejecutada
+     * @param baseDatos  nombre de la base de datos o conexión activa
+     * @param duracionMs tiempo de ejecución en milisegundos
+     */
+    public void agregar(String query, String baseDatos, long duracionMs) {
+        agregar(query, baseDatos, duracionMs, true);
+    }
+
+    /**
+     * Agrega una nueva entrada al historial con indicador de éxito.
+     *
+     * @param query      sentencia SQL ejecutada
+     * @param baseDatos  nombre de la base de datos o conexión activa
+     * @param duracionMs tiempo de ejecución en milisegundos
+     * @param exitosa    indica si la query se ejecutó sin errores
+     */
+    public void agregar(String query, String baseDatos, long duracionMs, boolean exitosa) {
+        if (historial.size() >= LIMITE) {
+            historial.pollFirst();
+        }
+        historial.addLast(new EntradaHistorial(
+                System.currentTimeMillis(),
+                query,
+                baseDatos,
+                duracionMs,
+                exitosa
+        ));
+    }
+
+    /**
+     * Retorna todas las entradas del historial en orden cronológico.
+     *
+     * @return lista de entradas del historial
+     */
+    public List<EntradaHistorial> obtenerTodos() {
+        return new ArrayList<>(historial);
+    }
+
+    /**
+     * Retorna la última entrada del historial.
+     *
+     * @return última entrada, o null si el historial está vacío
+     */
+    public EntradaHistorial obtenerUltimo() {
+        return historial.peekLast();
+    }
+
+    /**
+     * Vacía el historial completamente.
+     */
+    public void limpiar() {
+        historial.clear();
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa `HistorialQuerys`, un servicio que mantiene un registro FIFO de las últimas 50 queries ejecutadas en la sesión. Crea el record `EntradaHistorial` con timestamp, query, baseDatos, duracionMs y exitosa. Expone los métodos agregar(), obtenerTodos(), obtenerUltimo() y limpiar().

## Issue relacionado
Closes #279

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas