### PR TITLE
feat(servicio): implementar ExportadorExcel para exportar a .xlsx con Apache POI #284

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -39,6 +39,11 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/edu/sisinf/estante/servicio/ExportadorExcel.java
+++ b/src/main/java/edu/sisinf/estante/servicio/ExportadorExcel.java
@@ -1,0 +1,101 @@
+package edu.sisinf.estante.servicio;
+
+import edu.sisinf.estante.core.ErrorPersistencia;
+import edu.sisinf.estante.modelo.ResultadoQuery;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Servicio para exportar resultados de consultas a archivos Excel (.xlsx).
+ *
+ * Usa Apache POI para generar el archivo. La primera fila contiene
+ * los nombres de columna en negrita. Detecta tipos numéricos para
+ * formatearlos correctamente.
+ */
+public class ExportadorExcel {
+
+    /**
+     * Exporta un resultado de consulta a un archivo .xlsx.
+     *
+     * Si el archivo ya existe, se sobreescribe.
+     *
+     * @param resultado resultado de la consulta
+     * @param archivo   archivo destino
+     */
+    public void exportar(ResultadoQuery resultado, File archivo) {
+
+        if (resultado.getTipo() != ResultadoQuery.Tipo.LECTURA) {
+            throw new ErrorPersistencia(
+                    "Solo se pueden exportar resultados de lectura"
+            );
+        }
+
+        List<String> columnas = resultado.getColumnas();
+        List<List<Object>> filas = resultado.getFilas();
+
+        try (Workbook workbook = new XSSFWorkbook();
+             FileOutputStream salida = new FileOutputStream(archivo)) {
+
+            Sheet hoja = workbook.createSheet("Resultado");
+
+            // Estilo para cabeceras en negrita
+            CellStyle estiloCabecera = workbook.createCellStyle();
+            Font fuenteNegrita = workbook.createFont();
+            fuenteNegrita.setBold(true);
+            estiloCabecera.setFont(fuenteNegrita);
+
+            // Estilo para números
+            CellStyle estiloNumero = workbook.createCellStyle();
+            DataFormat formato = workbook.createDataFormat();
+            estiloNumero.setDataFormat(formato.getFormat("#,##0.##"));
+
+            // Fila de cabeceras
+            Row filaCabecera = hoja.createRow(0);
+            for (int c = 0; c < columnas.size(); c++) {
+                Cell celda = filaCabecera.createCell(c);
+                celda.setCellValue(columnas.get(c));
+                celda.setCellStyle(estiloCabecera);
+            }
+
+            // Filas de datos
+            for (int f = 0; f < filas.size(); f++) {
+                Row fila = hoja.createRow(f + 1);
+                List<Object> datos = filas.get(f);
+
+                for (int c = 0; c < datos.size(); c++) {
+                    Cell celda = fila.createCell(c);
+                    Object valor = datos.get(c);
+
+                    if (valor == null) {
+                        celda.setBlank();
+                    } else if (valor instanceof Number numero) {
+                        celda.setCellValue(numero.doubleValue());
+                        celda.setCellStyle(estiloNumero);
+                    } else if (valor instanceof Boolean booleano) {
+                        celda.setCellValue(booleano);
+                    } else {
+                        celda.setCellValue(valor.toString());
+                    }
+                }
+            }
+
+            // Ajustar ancho de columnas automáticamente
+            for (int c = 0; c < columnas.size(); c++) {
+                hoja.autoSizeColumn(c);
+            }
+
+            workbook.write(salida);
+
+        } catch (IOException e) {
+            throw new ErrorPersistencia(
+                    "Error al exportar archivo Excel",
+                    e
+            );
+        }
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa `ExportadorExcel`, un servicio que exporta resultados de consultas SQL a archivos .xlsx usando Apache POI 5.2.5. La primera fila tiene los nombres de columna en negrita. Detecta tipos numéricos y booleanos para formatearlos correctamente. Agrega la dependencia `poi-ooxml:5.2.5` al `pom.xml`.

## Issue relacionado
Closes #284 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/07273729-864f-4095-a657-533f79dd2df9" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d251aa9e-8bbc-40a7-afa9-721b552d4633" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/41f044a4-9b63-403e-9536-dde0ab8f0efd" />
