### PR TITLE
feat(controller): implementar resaltado de sintaxis básico en PanelEditorSQL #287

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -39,6 +39,16 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.fxmisc.richtext</groupId>
+            <artifactId>richtextfx</artifactId>
+            <version>0.11.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/edu/sisinf/estante/controller/PanelEditorSQLController.java
+++ b/src/main/java/edu/sisinf/estante/controller/PanelEditorSQLController.java
@@ -1,56 +1,104 @@
 package edu.sisinf.estante.controller;
 
 import edu.sisinf.estante.util.SqlValidator;
-
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.control.TextArea;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+import org.fxmisc.richtext.CodeArea;
+import org.fxmisc.richtext.model.StyleSpans;
+import org.fxmisc.richtext.model.StyleSpansBuilder;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * Controller del panel editor SQL.
- * Permite al usuario escribir y ejecutar consultas SQL.
- * El editor no ejecuta queries directamente: dispara un callback
- * registrado externamente con el texto actual del editor.
+ * Controller del panel editor SQL con resaltado de sintaxis básico.
+ * Usa RichTextFX CodeArea para mostrar keywords SQL en azul,
+ * strings en verde y comentarios en gris.
  */
 public class PanelEditorSQLController {
+
+    private static final String[] KEYWORDS = {
+        "SELECT", "FROM", "WHERE", "JOIN", "ON", "GROUP BY", "ORDER BY",
+        "HAVING", "INSERT", "UPDATE", "DELETE", "INTO", "VALUES", "SET",
+        "CREATE", "DROP", "ALTER", "TABLE", "INDEX", "VIEW", "AND", "OR",
+        "NOT", "NULL", "AS", "DISTINCT", "LIMIT", "OFFSET", "INNER",
+        "LEFT", "RIGHT", "OUTER", "FULL", "CROSS", "UNION", "ALL"
+    };
+
+    private static final Pattern PATRON = Pattern.compile(
+        "(?<KEYWORD>\\b(" + String.join("|", KEYWORDS) + ")\\b)"
+        + "|(?<STRING>'[^']*')"
+        + "|(?<COMMENT>--[^\n]*)",
+        Pattern.CASE_INSENSITIVE
+    );
 
     @FXML private Button btnEjecutar;
     @FXML private Button btnLimpiar;
     @FXML private Label labelConexionActiva;
-    @FXML private TextArea areaSQL;
+    @FXML private CodeArea areaSQL;
 
     private Consumer<String> onEjecutar;
 
     /**
-     * Inicializa el controller conectando los botones y el atajo de teclado.
+     * Inicializa el controller conectando los botones y el resaltado de sintaxis.
      */
     @FXML
     public void initialize() {
-
-        // Botón limpiar
         btnLimpiar.setOnAction(e -> areaSQL.clear());
-
-        // Botón ejecutar
         btnEjecutar.setOnAction(e -> disparar());
 
-        // Ctrl+Enter dispara el callback sin agregar salto de línea
         areaSQL.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             if (event.getCode() == KeyCode.ENTER && event.isControlDown()) {
                 event.consume();
                 disparar();
             }
         });
+
+        // Resaltado de sintaxis en tiempo real
+        areaSQL.textProperty().addListener((obs, oldText, newText) ->
+            areaSQL.setStyleSpans(0, calcularResaltado(newText))
+        );
+
+        // CSS inline para los estilos
+        areaSQL.getStylesheets().add(
+            "data:text/css," +
+            ".keyword { -fx-fill: #0000cc; -fx-font-weight: bold; }" +
+            ".string  { -fx-fill: #008000; }" +
+            ".comment { -fx-fill: #808080; -fx-font-style: italic; }"
+        );
+    }
+
+    /**
+     * Calcula los StyleSpans para resaltar keywords, strings y comentarios.
+     */
+    private StyleSpans<Collection<String>> calcularResaltado(String texto) {
+        Matcher matcher = PATRON.matcher(texto);
+        StyleSpansBuilder<Collection<String>> builder = new StyleSpansBuilder<>();
+        int ultimo = 0;
+
+        while (matcher.find()) {
+            String estilo =
+                matcher.group("KEYWORD") != null ? "keyword" :
+                matcher.group("STRING")  != null ? "string"  :
+                "comment";
+
+            builder.add(Collections.emptyList(), matcher.start() - ultimo);
+            builder.add(Collections.singleton(estilo), matcher.end() - matcher.start());
+            ultimo = matcher.end();
+        }
+
+        builder.add(Collections.emptyList(), texto.length() - ultimo);
+        return builder.create();
     }
 
     /**
      * Registra el callback que se invoca al ejecutar una query.
-     *
-     * @param callback {@code Consumer<String>} que recibe el texto del editor.
      */
     public void setOnEjecutar(Consumer<String> callback) {
         this.onEjecutar = callback;
@@ -58,9 +106,6 @@ public class PanelEditorSQLController {
 
     /**
      * Actualiza el label de conexión activa.
-     *
-     * @param descripcion Descripción de la conexión activa.
-     *                    Si es {@code null}, muestra "Sin conexión".
      */
     public void setConexionActiva(String descripcion) {
         labelConexionActiva.setText(descripcion != null ? descripcion : "Sin conexión");
@@ -68,8 +113,6 @@ public class PanelEditorSQLController {
 
     /**
      * Devuelve el texto actual del editor SQL.
-     *
-     * @return Texto escrito en el {@code TextArea}.
      */
     public String getTextoSQL() {
         return areaSQL.getText();
@@ -79,24 +122,16 @@ public class PanelEditorSQLController {
      * Dispara el callback si el texto no está vacío.
      */
     private void disparar() {
-
-    String texto = areaSQL.getText();
-
-    if (texto.isBlank() || onEjecutar == null) {
-        return;
-    }
-
-    if (SqlValidator.esDestructiva(texto)) {
-
-        boolean confirmar =
-                DialogoConfirmacionDML.confirmar(texto);
-
-        if (!confirmar) {
+        String texto = areaSQL.getText();
+        if (texto.isBlank() || onEjecutar == null) {
             return;
         }
+        if (SqlValidator.esDestructiva(texto)) {
+            boolean confirmar = DialogoConfirmacionDML.confirmar(texto);
+            if (!confirmar) {
+                return;
+            }
+        }
+        onEjecutar.accept(texto);
     }
-
-    onEjecutar.accept(texto);
-}
-
 }

--- a/src/main/resources/fxml/PanelEditorSQL.fxml
+++ b/src/main/resources/fxml/PanelEditorSQL.fxml
@@ -1,28 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Separator?>
-<?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.ToolBar?>
 <?import javafx.scene.layout.VBox?>
-
+<?import org.fxmisc.richtext.CodeArea?>
 <VBox xmlns="http://javafx.com/javafx"
       xmlns:fx="http://javafx.com/fxml"
       fx:controller="edu.sisinf.estante.controller.PanelEditorSQLController"
       VBox.vgrow="ALWAYS">
-
     <ToolBar>
         <Button fx:id="btnEjecutar" text="Ejecutar (Ctrl+Enter)"/>
         <Button fx:id="btnLimpiar" text="Limpiar"/>
         <Separator orientation="VERTICAL"/>
         <Label fx:id="labelConexionActiva" text="Sin conexión"/>
     </ToolBar>
-
-    <TextArea fx:id="areaSQL"
+    <CodeArea fx:id="areaSQL"
               promptText="Escribe tu consulta SQL aquí..."
-              wrapText="false"
               style="-fx-font-family: monospace;"
               VBox.vgrow="ALWAYS"/>
-
 </VBox>


### PR DESCRIPTION
## ¿Qué hace este PR?
Reemplaza el TextArea del editor SQL por un CodeArea de RichTextFX. Implementa resaltado básico de sintaxis SQL: keywords en azul, strings entre comillas en verde y comentarios en gris. Agrega la dependencia `richtextfx:0.11.2` al `pom.xml`. La funcionalidad de ejecutar queries con Ctrl+Enter se mantiene intacta.

## Issue relacionado
Closes #287 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/83b56d99-465c-4e8a-bb37-e92d3fe05a22" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e88a462c-4ca9-4244-aaec-2caabd0006c5" />
