### PR TITLE
fix: corregir .gitignore para excluir artefactos de Maven y archivos …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ target/
 # IDEs / Editores
 .vscode/
 .idea/
+*.iml
 *.swp
 *.swo
 
@@ -62,6 +63,7 @@ htmlcov/
 .classpath
 .project
 .settings/
+*.class
 
 # Python
 venv/


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige y extiende las reglas del archivo `.gitignore` en la raíz del proyecto para asegurar la exclusión completa de artefactos de compilación generados por Maven y archivos temporales o de configuración creados por entornos de desarrollo (IDEs). Específicamente, se añadieron los patrones globales `*.iml` y `*.class`, complementando las exclusiones existentes para evitar que metadatos locales interfieran con el control de versiones de los demás colaboradores.

## Issue relacionado
Closes #246

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
- Se verificó la estructura completa del archivo `.gitignore` para mantener intactas las reglas preexistentes de acuerdo con las instrucciones.
- Se realizaron pruebas locales de seguimiento en Git Bash forzando la creación de archivos de prueba (`test.class` y `proyecto.iml`). Al ejecutar `git status`, se comprobó con éxito que Git los ignora por completo y no los reporta como archivos sin seguimiento (Untracked files), validando los criterios de aceptación del issue de manera exitosa.
 
<img width="711" height="296" alt="image" src="https://github.com/user-attachments/assets/4d456ff6-c40b-4c15-a67e-5350e7cd2b8f" />