### PR TITLE
chore: agregar .gitattributes para normalizar finales de línea

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # Normalizar finales de línea a LF en archivos de texto
+* text=auto
 *.java text eol=lf
 *.xml text eol=lf
 *.fxml text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Normalizar finales de línea a LF en archivos de texto
+*.java text eol=lf
+*.xml text eol=lf
+*.fxml text eol=lf
+*.md text eol=lf
+*.properties text eol=lf
+
+# Archivos binarios: no modificar finales de línea
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea `.gitattributes` para normalizar finales de línea (LF) en archivos de texto.

## Cambios
- Nuevo archivo `.gitattributes` en la raíz.
- `* text=auto` como primera regla para detección automática de archivos de texto.
- Reglas para `.java`, `.xml`, `.fxml`, `.md`, `.properties` → `text eol=lf`.
- Archivos de imagen (`.png`, `.jpg`, `.jpeg`, `.gif`, `.ico`) → `binary`.

## Issue relacionado
Closes #325

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas