### PR TITLE
chore: configurar maven-javafx-plugin para compilar y ejecutar la aplicación JavaFX - Closes#322

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,18 @@ Estante ayuda a resolver:
 - Un servidor MySQL en ejecución (local o remoto)
 # Pasos
 
+
+```bash
 # 1. Clona el repositorio:
 git clone https://github.com/tu-usuario/estante.git
 cd estante
 
 # 2. Compila el proyecto:
-javac --module-path /ruta/a/javafx-sdk/lib --add-modules javafx.controls,javafx.fxml -d out src/**/*.java
+mvn compile
 
-# 3. Ejecuta la aplicación:    
-java --module-path /ruta/a/javafx-sdk/lib --add-modules javafx.controls,javafx.fxml -cp out Main  
+# 3. Ejecuta la aplicación:
+mvn javafx:run
+``` 
 
 ## Uso rápido
 - Abre Estante y completa los datos de conexión (host, puerto, usuario y contraseña)


### PR DESCRIPTION
## ¿Qué hace este PR?
Se verificó que `pom.xml` ya contaba con el plugin `org.openjfx:javafx-maven-plugin` correctamente configurado (versión `0.0.8`, `mainClass: edu.sisinf.estante.App`), por lo que no fue necesario realizar cambios en ese archivo.

Se actualizó `README.md` en la sección de Instalación para reemplazar los pasos manuales de compilación y ejecución (`javac`/`java --module-path`) por el flujo Maven (`mvn compile` / `mvn javafx:run`).

## Archivos modificados

- `README.md` — pasos de instalación actualizados a `mvn javafx:run`

## Archivos sin cambios

- `pom.xml` — plugin ya estaba configurado correctamente; no se tocó

## Criterios de aceptación

- [x] `pom.xml` tiene la `mainClass` configurada correctamente (`edu.sisinf.estante.App`)
- [x] `mvn javafx:run` está documentado en `README.md`
- [x] No se modificaron archivos de código fuente

## Issue relacionado
Closes #322

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ ] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde