### PR TITLE
chore: configurar maven-javafx-plugin para compilar y ejecutar la aplicación JavaFX - Closes#322

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,4 @@
 # Estante
-## Inicio Rápido
-
-```bash
-git clone https://github.com/sis-inf/estante.git
-mvn compile
-mvn javafx:run
-```
-
-Al ejecutar `mvn javafx:run` se abrirá la ventana principal de la aplicación Estante con su interfaz gráfica JavaFX.
 
 Gestor de base de datos con interfaz gráfica desarrollado en Java y JavaFX.
 

--- a/README.md
+++ b/README.md
@@ -67,15 +67,18 @@ Estante ayuda a resolver:
 - Un servidor MySQL en ejecución (local o remoto)
 # Pasos
 
+
+```bash
 # 1. Clona el repositorio:
 git clone https://github.com/tu-usuario/estante.git
 cd estante
 
 # 2. Compila el proyecto:
-javac --module-path /ruta/a/javafx-sdk/lib --add-modules javafx.controls,javafx.fxml -d out src/**/*.java
+mvn compile
 
-# 3. Ejecuta la aplicación:    
-java --module-path /ruta/a/javafx-sdk/lib --add-modules javafx.controls,javafx.fxml -cp out Main  
+# 3. Ejecuta la aplicación:
+mvn javafx:run
+``` 
 
 ## Uso rápido
 - Abre Estante y completa los datos de conexión (host, puerto, usuario y contraseña)


### PR DESCRIPTION
## ¿Qué hace este PR?
Se verificó que `pom.xml` ya contaba con el plugin `org.openjfx:javafx-maven-plugin` correctamente configurado, por lo que no fue necesario realizar cambios en ese archivo.

La notación `org.openjfx:javafx-maven-plugin` es la forma abreviada de identificar el plugin donde `org.openjfx` corresponde al `groupId` y `javafx-maven-plugin` al `artifactId`. El plugin presente en `pom.xml` cumple exactamente con lo solicitado en el issue:

```xml
<plugin>
    <groupId>org.openjfx</groupId>
    <artifactId>javafx-maven-plugin</artifactId>
    <version>0.0.8</version>
    <configuration>
        <mainClass>edu.sisinf.estante.App</mainClass>
    </configuration>
</plugin>
```

Se actualizó `README.md` para documentar el comando `mvn javafx:run` en la sección de Instalación, reemplazando los pasos manuales de compilación y ejecución con `javac`/`java --module-path`. Se eliminó también la sección "Inicio Rápido" que duplicaba los mismos comandos.

## Archivos modificados

- `README.md` — sección de Instalación actualizada a `mvn javafx:run`, sección "Inicio Rápido" eliminada por duplicación

## Archivos sin cambios

- `pom.xml` — plugin `org.openjfx:javafx-maven-plugin` ya estaba configurado correctamente; no se modificó

## Criterios de aceptación

- [x] `pom.xml` tiene la `mainClass` configurada correctamente (`edu.sisinf.estante.App`)
- [x] `mvn javafx:run` está documentado en `README.md`
- [x] No se modificaron archivos de código fuente

## Issue relacionado
Closes #322 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ ] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde