### PR TITLE
fix: close ConnectionProvider class

### DIFF
--- a/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
+++ b/src/main/java/edu/sisinf/estante/core/ConnectionProvider.java
@@ -133,3 +133,4 @@ public class ConnectionProvider {
         );
     }
 } 
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige la llave de cierre faltante en ConnectionProvider.java

## Issue relacionado
Closes #438 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se ejecutó mvn compile.

El error original en ConnectionProvider.java ya no aparece. La compilación avanza y actualmente falla por errores distintos en ConexionDAOMySQL.java, archivo que no forma parte de este issue.

Solo se modificó:

src/main/java/edu/sisinf/estante/core/ConnectionProvider.java