### PR TITLE
chore: agregar pre-commit hooks para Java y documentar instalacion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+        name: Trim Trailing Whitespace
+      - id: end-of-file-fixer
+        name: Fix End of Files
+      - id: check-xml
+        name: Check XML/FXML Syntax
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: no-commit-to-branch
+        name: Protect Main Branch
+        args: [--branch, main]
+
+  - repo: local
+    hooks:
+      - id: verificar-estructura
+        name: Verificación de Estructura de Proyecto
+        entry: bash scripts/verificar_estructura.sh
+        language: script
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,4 +158,11 @@ Utilizando el subpaquete correcto según su propósito en el sistema:
 
 ---
 
+## Configuración de Calidad de Código (Pre-commit)
+
+Para mantener la consistencia del código y la estructura del proyecto, se utilizan hooks de `pre-commit`. Antes de realizar tu primer commit, es obligatorio instalar los hooks ejecutando el siguiente comando en la raíz del proyecto:
+
+```bash
+pre-commit install
+
 **¡Gracias por contribuir al proyecto!**


### PR DESCRIPTION
## ¿Qué hace este PR?
Configura los pre-commit hooks para el proyecto mediante la creación del archivo .pre-commit-config.yaml. Se incluyen hooks para remover espacios en blanco al final de las líneas, corregir fines de archivo, validar sintaxis XML/FXML y proteger la rama main. Además, se añade un hook local para ejecutar el script de verificación de estructura y se documenta el paso de instalación en CONTRIBUTING.md.

## Issue relacionado
Closes #329 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas