### PR TITLE
chore: crear Makefile con targets Maven para desarrollo local - Closes#321

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: build test package run clean coverage checkstyle help
+
+build:
+	mvn compile
+
+test:
+	mvn test
+
+package:
+	mvn package -DskipTests
+
+run:
+	mvn javafx:run
+
+clean:
+	mvn clean
+
+coverage:
+	mvn jacoco:report
+
+checkstyle:
+	mvn checkstyle:check
+
+help:
+	@echo "Targets disponibles:"
+	@echo "  build       - Compila el proyecto (mvn compile)"
+	@echo "  test        - Ejecuta los tests (mvn test)"
+	@echo "  package     - Empaqueta el proyecto sin tests (mvn package -DskipTests)"
+	@echo "  run         - Ejecuta la aplicacion JavaFX (mvn javafx:run)"
+	@echo "  clean       - Limpia los artefactos generados (mvn clean)"
+	@echo "  coverage    - Genera reporte de cobertura JaCoCo (mvn jacoco:report)"
+	@echo "  checkstyle  - Verifica estilo de codigo (mvn checkstyle:check)"
+	@echo "  help        - Muestra este mensaje de ayuda"


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea un `Makefile` en la raíz del proyecto para simplificar el flujo de desarrollo local, evitando que los desarrolladores tengan que recordar y escribir los comandos Maven completos a mano. Con él basta ejecutar `make build`, `make test`, etc.
## Cambios realizados

Se crea `Makefile` en la raíz del proyecto con los siguientes targets:

| Target | Comando |
|---|---|
| `make build` | `mvn compile` |
| `make test` | `mvn test` |
| `make package` | `mvn package -DskipTests` |
| `make run` | `mvn javafx:run` |
| `make clean` | `mvn clean` |
| `make coverage` | `mvn jacoco:report` |
| `make checkstyle` | `mvn checkstyle:check` |
| `make help` | Lista todos los targets con descripción |

## Archivos modificados

- `Makefile` *(nuevo)*

## Notas

No se modificó ningún archivo de código fuente ni de configuración existente.

Durante la verificación de los criterios de aceptación se detectaron los siguientes errores preexistentes en el proyecto, fuera del alcance de este issue:

- **`make test`** — errores de compilación en `ConnectionFlowTest.java` (dependencia de Mockito Jupiter ausente) y `DBConfigTest.java` (firma del constructor de `DBConfig` y método `toJdbcUrl()` no coinciden con la implementación actual).
- **`make run`** — falla la ejecución del plugin JavaFX.
- **`make coverage`** — JaCoCo no está configurado en el `pom.xml`, Maven no reconoce el prefijo `jacoco`.
- **`make checkstyle`** — 988 violaciones de estilo en el código fuente existente.

## Issue relacionado
Closes #321

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde