### PR TITLE
chore: configurar GitHub Actions matrix para Java 17 y Java 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   validar-pr:
     runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        java-version: [17, 21]
+
     steps:
       - name: Verificar descripción del PR
         run: |
@@ -27,10 +32,10 @@ jobs:
       - name: Checkout del repositorio
         uses: actions/checkout@v4
 
-      - name: Configurar Java JDK 21
+      - name: Configurar Java JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
           cache: 'maven'
 
@@ -47,6 +52,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: checkstyle-report
+          name: checkstyle-report-java-${{ matrix.java-version }}
           path: target/checkstyle-result.xml
           if-no-files-found: ignore

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
     <version>0.1.0</version>
     <packaging>jar</packaging>
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javafx.version>21.0.2</javafx.version>
         <junit.version>5.10.2</junit.version>
@@ -87,8 +87,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>17</source>
+                    <target>17</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
@@ -131,12 +131,12 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-checkstyle-plugin</artifactId>
-              <version>3.6.0</version>                        <!-- wrapper Maven del plugin -->
+              <version>3.6.0</version>
               <dependencies>
                   <dependency>
                       <groupId>com.puppycrawl.tools</groupId>
                       <artifactId>checkstyle</artifactId>
-                      <version>${checkstyle.version}</version> <!-- motor real; se fija para reproducibilidad -->
+                      <version>${checkstyle.version}</version>
                   </dependency>
               </dependencies>
               <configuration>


### PR DESCRIPTION
## ¿Qué hace este PR?
Configura una estrategia de matriz (Matrix) en el flujo de trabajo de integración continua (GitHub Actions) para compilar y validar de manera automatizada el proyecto utilizando las versiones de Java 17 LTS y Java 21 LTS en paralelo. Asimismo, ajusta el archivo `pom.xml` fijando los parámetros `source` y `target` del compilador de Maven en la versión 17, asegurando con esto la retrocompatibilidad y la correcta construcción del artefacto en ambos entornos de ejecución.

## Issue relacionado
Closes #326

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [X] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [X] Mi código sigue los estándares del proyecto
- [X] Actualicé la documentación correspondiente
- [X] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
- **Configuración de Matrix Multi-versión:** El flujo de GitHub Actions ejecuta correctamente las tareas en paralelo dividiendo el entorno para validar la construcción tanto bajo el JDK 17 como bajo el JDK 21 de forma independiente.
<img width="998" height="671" alt="image" src="https://github.com/user-attachments/assets/a30eb2c0-b014-4721-be99-63dbfaf551e7" />
<img width="996" height="673" alt="image" src="https://github.com/user-attachments/assets/1390d71f-60b0-489f-927c-a21dae9bb8f6" />
<img width="1008" height="322" alt="image" src="https://github.com/user-attachments/assets/c12c471d-3039-487e-85d9-7ae1b031430d" />

- **Validación del Compilador Local:** Al ejecutar los comandos de prueba en la consola local, el plugin del compilador de Maven (`maven-compiler-plugin`) procesa los archivos fuente bajo la directiva estricta de `debug target 17`.
<img width="1305" height="683" alt="image" src="https://github.com/user-attachments/assets/97ca0793-20a4-4684-8e55-51a0b6c918ad" />
<img width="1216" height="395" alt="image" src="https://github.com/user-attachments/assets/26b20a48-7710-4993-89fb-012a8bfe5ce7" />
