### PR TITLE
chore: agregar .github/dependabot.yml para Maven y GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+
+* package-ecosystem: "maven"
+  directory: "/"
+  schedule:
+  interval: "monthly"
+  target-branch: "dev"
+  open-pull-requests-limit: 3
+  commit-message:
+  prefix: "chore(deps)"
+
+* package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+  interval: "monthly"
+  target-branch: "dev"
+  open-pull-requests-limit: 3
+  commit-message:
+  prefix: "chore(deps)"


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el archivo .github/dependabot.yml para automatizar la actualización de dependencias del proyecto.

Incluye:

* Configuración para Maven.
* Configuración para GitHub Actions.
* Frecuencia mensual.
* Rama objetivo dev.
* Límite de 3 Pull Requests abiertos.
* Prefijo chore(deps) para los commits generados.

## Issue relacionado
Closes #317

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la configuracion correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se agregó el archivo .github/dependabot.yml.
