### PR TITLE
Fix/corregir package string utils

### DIFF
--- a/src/test/java/com/estante/util/StringUtilsTest.java
+++ b/src/test/java/com/estante/util/StringUtilsTest.java
@@ -1,0 +1,69 @@
+package edu.sisinf.estante.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StringUtilsTest {
+
+    @Test
+    @DisplayName("Truncar texto corto sin cambios")
+    void testTruncarTextoCorto() {
+        String resultado = StringUtils.truncar("Hola", 10);
+        assertEquals("Hola", resultado);
+    }
+
+    @Test
+    @DisplayName("Truncar texto largo con puntos suspensivos")
+    void testTruncarTextoLargo() {
+        String resultado = StringUtils.truncar("Hola mundo", 4);
+        assertEquals("Hola...", resultado);
+    }
+
+    @Test
+    @DisplayName("Enmascarar valor normal")
+    void testEnmascararNormal() {
+        String resultado = StringUtils.enmascarar("123456789");
+        assertEquals("*****6789", resultado);
+    }
+
+    @Test
+    @DisplayName("Enmascarar valor null")
+    void testEnmascararNull() {
+        String resultado = StringUtils.enmascarar(null);
+        assertNull(resultado);
+    }
+
+    @Test
+    @DisplayName("Enmascarar valor vacío")
+    void testEnmascararVacio() {
+        String resultado = StringUtils.enmascarar("");
+        assertEquals("", resultado);
+    }
+
+    @Test
+    @DisplayName("Capitalizar varias palabras")
+    void testCapitalizarVariasPalabras() {
+        String resultado = StringUtils.capitalizar("hola mundo");
+        assertEquals("Hola Mundo", resultado);
+    }
+
+    @Test
+    @DisplayName("esVacioONulo con null")
+    void testEsVacioONuloNull() {
+        assertTrue(StringUtils.esVacioONulo(null));
+    }
+
+    @Test
+    @DisplayName("esVacioONulo con vacío")
+    void testEsVacioONuloVacio() {
+        assertTrue(StringUtils.esVacioONulo(""));
+    }
+
+    @Test
+    @DisplayName("esVacioONulo con texto normal")
+    void testEsVacioONuloTexto() {
+        assertFalse(StringUtils.esVacioONulo("Hola"));
+    }
+}

--- a/src/test/java/com/estante/util/StringUtilsTest.java
+++ b/src/test/java/com/estante/util/StringUtilsTest.java
@@ -1,4 +1,4 @@
-package edu.sisinf.estante.util;
+package com.estante.util;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige de forma definitiva la declaración de los paquetes en StringUtilsTest.java y StringUtils.java para que utilicen el namespace correcto com.estante.util de manera consistente. Asimismo, se asegura la ubicación del archivo de pruebas dentro de la ruta estructurada src/test/java/com/estante/util/, garantizando la correcta visibilidad entre el componente principal y su respectivo test.

## Issue relacionado
Closes #464 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas