### PR TITLE
chore: crear scripts/verificar_estructura.sh para validar que el códi…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
           echo "✅ PR referencia un issue"
       - name: Checkout del repositorio
         uses: actions/checkout@v4
+
+      - name: Verificar estructura Maven
+        run: bash scripts/verificar_estructura.sh
+
       - name: Configurar Java JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v4
         with:

--- a/scripts/verificar_estructura.sh
+++ b/scripts/verificar_estructura.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "Iniciando verificación de conformidad con estructura Maven..."
+ERROR=0
+
+ARCHIVOS_JAVA=$(find . -type f -name "*.java" ! -path "./src/main/java/*" ! -path "./src/test/java/*" ! -path "./scripts/*" ! -path "./target/*")
+
+if [ ! -z "$ARCHIVOS_JAVA" ]; then
+    echo "[ERROR] Archivos .java detectados en rutas no permitidas:"
+    echo "$ARCHIVOS_JAVA"
+    ERROR=1
+fi
+
+ARCHIVOS_FXML=$(find . -type f -name "*.fxml" ! -path "./src/main/resources/*" ! -path "./target/*")
+
+if [ ! -z "$ARCHIVOS_FXML" ]; then
+    echo "[ERROR] Archivos .fxml detectados en rutas no permitidas:"
+    echo "$ARCHIVOS_FXML"
+    ERROR=1
+fi
+
+if [ $ERROR -eq 1 ]; then
+    echo "[FALLO] La estructura del proyecto no cumple con el estándar requerido."
+    exit 1
+else
+    echo "✅ Validación de estructura Maven exitosa."
+    exit 0
+fi


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea un script de automatización en Bash (`scripts/verificar_estructura.sh`) encargado de validar que la arquitectura del proyecto cumpla estrictamente con la estructura de directorios estándar de Maven. Adicionalmente, integra este script como un paso automatizado dentro del flujo de integración continua (`.github/workflows/ci.yml`) ejecutándose inmediatamente después del checkout, lo que asegura que cualquier PR que introduzca archivos desorganizados fuera de las rutas permitidas sea detectado y bloqueado automáticamente.

## Cambios
- **Nuevo archivo:** `scripts/verificar_estructura.sh` con la lógica de búsqueda de archivos `.java` y `.fxml` fuera de sus carpetas estándar mediante comandos `find`.
- **Modificación:** `.github/workflows/ci.yml` añadiendo el paso "Verificar estructura Maven" antes de las etapas de compilación y pruebas.

## Issue relacionado
Closes #327

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
A continuación se adjuntan las pruebas locales que demuestran el funcionamiento correcto del script en los dos escenarios requeridos:
**Escenario limpio:** Validación exitosa cuando los archivos están en las carpetas correctas.
<img width="781" height="126" alt="image" src="https://github.com/user-attachments/assets/229bdd7d-f9d2-4d0e-b38b-f5c5aece24b7" />
<img width="1141" height="600" alt="image" src="https://github.com/user-attachments/assets/9927aa7a-7ce1-4e0a-ae97-80a65b5ffcf7" />
**Escenario con error:** Detección de un archivo `.java` en la raíz (fuera de `src/main/java`), interrumpiendo el flujo con un código de salida `1`.
<img width="786" height="383" alt="image" src="https://github.com/user-attachments/assets/c1fe440a-f032-40a6-a36f-0e139d49be70" />

