### PR TITLE
feat(servicio): implementar ConexionTester — probar una conexión antes de guardarla

### DIFF
--- a/src/main/java/com/estante/modelo/ResultadoPrueba.java
+++ b/src/main/java/com/estante/modelo/ResultadoPrueba.java
@@ -1,0 +1,8 @@
+package com.estante.modelo;
+
+public record ResultadoPrueba(
+    boolean exitosa,
+    long tiempoMs,
+    String mensajeError
+) {}
+

--- a/src/main/java/com/estante/servicio/ConexionTester.java
+++ b/src/main/java/com/estante/servicio/ConexionTester.java
@@ -1,0 +1,40 @@
+package com.estante.servicio;
+
+import com.estante.modelo.ResultadoPrueba;
+import edu.sisinf.estante.modelo.Conexion;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+public class ConexionTester {
+
+    /**
+     * Prueba una conexión construyendo la URL JDBC con los datos reales de la clase Conexion.
+     */
+    public ResultadoPrueba probar(Conexion conexion) {
+        long inicio = System.currentTimeMillis();
+        
+        // Construimos el string JDBC: jdbc:mysql://host:puerto/basedatos
+        String urlJdbc = String.format("jdbc:mysql://%s:%d/%s", 
+                conexion.getHost(), 
+                conexion.getPuerto(), 
+                conexion.getBasedatos());
+        
+        try (Connection conn = DriverManager.getConnection(
+                urlJdbc, 
+                conexion.getUsuario(), 
+                conexion.getPassword());
+             Statement stmt = conn.createStatement()) {
+            
+            stmt.executeQuery("SELECT 1");
+            
+            long tiempoMs = System.currentTimeMillis() - inicio;
+            return new ResultadoPrueba(true, tiempoMs, null);
+            
+        } catch (Exception e) {
+            long tiempoMs = System.currentTimeMillis() - inicio;
+            String mensajeError = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            return new ResultadoPrueba(false, tiempoMs, mensajeError);
+        }
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?

Implementa la funcionalidad para probar la validez de los parámetros de una nueva conexión a base de datos antes de que el usuario proceda a guardarla en el sistema (mejora de UX).

Se desarrollaron dos componentes clave bajo las especificaciones de diseño modular:
- `ResultadoPrueba`: Un record inmutable que encapsula el estado de éxito (`exitosa`), la duración del intento en milisegundos (`tiempoMs`), y el rastreo de errores detallados (`mensajeError`).
- `ConexionTester`: Servicio encargado de validar el enlace de forma dinámica utilizando los parámetros reales de la clase `edu.sisinf.estante.modelo.Conexion` mediante el uso eficiente de bloques *try-with-resources* en Java, asegurando el cierre inmediato de la conexión tras la ejecución de la consulta de diagnóstico estándar (`SELECT 1`).

El historial de Git ha sido unificado en un único commit limpio que afecta exclusivamente a estos dos nuevos archivos.

## Issue relacionado
Closes #293 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1078" height="277" alt="image" src="https://github.com/user-attachments/assets/77b14b8a-6f10-4033-8b8d-ecd334a35cfd" />
<img width="1816" height="807" alt="image" src="https://github.com/user-attachments/assets/e5daeaa7-e02f-4e3b-83cc-37097bd374f8" />
