### PR TITLE
fix: corregir package incorrecto en StringUtilsTest.java y StringUtils.java

### DIFF
--- a/src/test/java/com/estante/StringUtilsTest.java
+++ b/src/test/java/com/estante/StringUtilsTest.java
@@ -1,4 +1,4 @@
-package edu.sisinf.estante.util;
+package com.estante.util;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## ¿Qué hace este PR?

Solo se corrige la inconsistencia de package en **StringUtilsTest.java**, alineándolos con la estructura del proyecto **com.estante.util** para permitir la correcta visibilidad de clases entre test y código principal. 

Para **StringUtils.java** no es necesario corregir el package, ya que se encuentra en la estructura del proyecto **com.estante.util**

## Issue relacionado
Closes #464 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1505" height="175" alt="image" src="https://github.com/user-attachments/assets/71a17796-6dcf-4f31-9bfb-a96b78862747" />
<img width="637" height="282" alt="image" src="https://github.com/user-attachments/assets/eb338bf2-0ada-4662-b20b-1360a37ecff6" />
