### PR TITLE
chore: agregar mockito-junit-jupiter y centralizar version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javafx.version>21.0.2</javafx.version>
         <junit.version>5.10.2</junit.version>
+        <mockito.version>5.10.0</mockito.version>
         <poi.version>5.2.5</poi.version>
         <checkstyle.version>10.21.4</checkstyle.version>
     </properties>
@@ -77,7 +78,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.10.0</version>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega la dependencia mockito-junit-jupiter para integración nativa de Mockito con JUnit 5, y centraliza la versión de Mockito en la propiedad ${mockito.version}. Esto permite que los tests que usan @ExtendWith(MockitoExtension.class) compilen correctamente.

## Issue relacionado
Closes #320

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas