### PR TITLE
feat(i18n): agregar formato de fecha/hora y números localizado según el idioma seleccionado

### DIFF
--- a/src/main/java/edu/sisinf/estante/controller/PanelHistorialController.java
+++ b/src/main/java/edu/sisinf/estante/controller/PanelHistorialController.java
@@ -10,6 +10,8 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.Locale;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -28,8 +30,6 @@ import java.util.function.Consumer;
 public class PanelHistorialController {
 
     private static final int MAX_QUERY_CHARS = 60;
-    private static final DateTimeFormatter FORMATO =
-            DateTimeFormatter.ofPattern("HH:mm:ss");
 
     @FXML private ListView<EntradaHistorial> listaHistorial;
     @FXML private Button btnLimpiar;
@@ -49,12 +49,19 @@ public class PanelHistorialController {
                 if (empty || entrada == null) {
                     setText(null);
                 } else {
+                    Locale locale = Locale.getDefault();
+                    DateTimeFormatter formatter =
+                        DateTimeFormatter.ofLocalizedDateTime(
+                            FormatStyle.SHORT
+                        ).withLocale(locale);
+                    
                     String hora = LocalDateTime
-                            .ofInstant(
-                                    Instant.ofEpochMilli(entrada.timestamp()),
-                                    ZoneId.systemDefault()
-                            )
-                            .format(FORMATO);
+                        .ofInstant(
+                            Instant.ofEpochMilli(entrada.timestamp()),
+                            ZoneId.systemDefault()
+                        )
+                        .format(formatter);
+                 
                     String query = entrada.query().length() > MAX_QUERY_CHARS
                             ? entrada.query().substring(0, MAX_QUERY_CHARS) + "..."
                             : entrada.query();


### PR DESCRIPTION
## ¿Qué hace este PR?

Reemplaza el formato fijo de fecha y hora por un formato localizado utilizando DateTimeFormatter.ofLocalizedDateTime y Locale, permitiendo que las fechas se muestren según la configuración regional del sistema.

## Issue relacionado
Closes #620 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1570" height="883" alt="image" src="https://github.com/user-attachments/assets/263a19e0-808e-456c-b8b6-9ef321577010" />
