### PR TITLE
feat(empaquetado): agregar modo portable (sin instalación, ejecutable desde una unidad USB)…

### DIFF
--- a/src/main/java/edu/sisinf/estante/config/ConfiguracionApp.java
+++ b/src/main/java/edu/sisinf/estante/config/ConfiguracionApp.java
@@ -6,6 +6,7 @@ package edu.sisinf.estante.config;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -30,6 +31,8 @@ public class ConfiguracionApp {
     /** Nombre del archivo que almacena las conexiones del usuario. */
     private static final String CONNECTIONS_FILE = "conexiones.json";
 
+    private static final String PORTABLE_FLAG = "portable.flag";
+
     /** Constructor privado para evitar instanciacion. */
     private ConfiguracionApp() {}
 
@@ -41,10 +44,13 @@ public class ConfiguracionApp {
      *
      * @return {@link Path} que apunta a {@code <user.home>/.estante/}
      */
-    public static Path directorioHome() {
-        return Paths.get(System.getProperty("user.home"), APP_DIRECTORY);
-    }
-
+   public static Path directorioHome() {
+       if (modoPortable()) {
+           return directorioEjecutable().resolve(APP_DIRECTORY);
+       }
+        
+       return Paths.get(System.getProperty("user.home"), APP_DIRECTORY);
+     }
     /**
      * Devuelve el archivo de conexiones de la aplicacion.
      *
@@ -69,6 +75,23 @@ public class ConfiguracionApp {
         try {
             Files.createDirectories(directorioHome());
         } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    private static boolean modoPortable() {
+        return Files.exists(directorioEjecutable().resolve(PORTABLE_FLAG));
+    }
+    
+    private static Path directorioEjecutable() {
+        try {
+            return Paths.get(
+                ConfiguracionApp.class
+                        .getProtectionDomain()
+                        .getCodeSource()
+                        .getLocation()
+                        .toURI())
+                .getParent();
+        } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
## ¿Qué hace este PR?

Este PR agrega soporte para un modo portable en la aplicación.

Cuando existe un archivo `portable.flag` junto al ejecutable, la aplicación almacena todos los archivos de configuración en una carpeta relativa al ejecutable. Si el archivo no está presente, se mantiene el comportamiento actual, utilizando el directorio `user.home` del usuario.

Con este cambio, la aplicación puede ejecutarse desde una unidad USB sin dejar archivos de configuración fuera de su propia carpeta.


## Issue relacionado
Closes #613 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1466" height="895" alt="image" src="https://github.com/user-attachments/assets/d5c6de09-bf97-4bfa-a60a-4973f43eb253" />
