### PR TITLE
fix(ci): corregir el lenguaje de CodeQL en security.yml — está escaneando javascript-typescript en un proyecto Java

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,10 @@ jobs:
       - name: Inicializar CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: javascript-typescript
+          languages: java
+
+      - name: Compilar proyecto (CodeQL Autobuild)
+        uses: github/codeql-action/autobuild@v4
 
       - name: Análisis de CodeQL
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## ¿Qué hace este PR?

Este PR corrige la configuración de CodeQL para que analice el código Java del proyecto en lugar de `javascript-typescript`.

Además, se agrega el paso de `autobuild` para que CodeQL compile automáticamente el proyecto antes del análisis, permitiendo que el escaneo de seguridad se ejecute correctamente sobre el código fuente Java.


## Issue relacionado
Closes #519 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1336" height="262" alt="image" src="https://github.com/user-attachments/assets/3e00e6d1-e621-4900-9918-bbb7f383ff93" />
