### PR TITLE
Limpiar .gitignore eliminando reglas innecesarias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,78 +3,27 @@
 Thumbs.db
 desktop.ini
 
-# Variables de entorno
-.env
-.env.local
-.env.*.local
-*.local
-
-# Logs
-*.log
-logs/
-npm-debug.log*
-
-# Dependencias
-node_modules/
-vendor/
-__pycache__/
-*.pyc
-*.pyo
-
-# Build / compilación
-dist/
-build/
-out/
+# Build / compilación (Java/Maven)
 target/
-*.o
-*.exe
-*.dll
-*.so
+*.class
 
 # IDEs / Editores
-.vscode/
 .idea/
+.vscode/
 *.iml
 *.swp
 *.swo
-
-# Cobertura de tests
-coverage/
-.coverage
-htmlcov/
-
-# Datos sensibles
-*.pem
-*.key
-*.cert
-
-# Archivos SQLite
-*.SQLite
-*.sqlite
-*.sqlite3
-*.db
-
-# dumps y backups
-*.sql.bak
-*.dump
-*.dumps
 
 # Java
 .classpath
 .project
 .settings/
-*.class
 
-# Python
-venv/
-.venv/
-.pytest_cache
-
-# Cobertura de tests
-coverage/
-.coverage
-htmlcov/
-.nyc_output/
+# Archivos SQLite
+*.db
+*.sqlite
+*.sqlite3
+*.SQLite
 
 # Datos sensibles
 *.pem
@@ -82,6 +31,12 @@ htmlcov/
 *.cert
 id_rsa
 id_rsa.pub
+database.properties
+
+# Dumps y backups
+*.sql.bak
+*.dump
+*.dumps
 
 # Temporales
 *.tmp
@@ -89,5 +44,4 @@ id_rsa.pub
 *.bak
 
 # Otros
-.eslintcache
 .gitignore.local


### PR DESCRIPTION
## ¿Qué hace este PR?

Limpia el archivo `.gitignore` eliminando reglas y secciones que no son relevantes para este proyecto Java/Maven. Se eliminaron reglas de Node.js y Python, se quitaron secciones duplicadas y se dejó únicamente lo pertinente para el proyecto.

## Issue relacionado

Closes #644

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

No aplica. Se realizó únicamente la limpieza del archivo `.gitignore`.