### PR TITLE
chore(build): corregir rutas obsoletas en CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,9 @@
 *                                             @erwinsaul
 
 # Revisores por módulos específicos
-/src/main/java/com/estante/dao/               @erwinsaul
-/src/main/java/com/estante/servicio/          @erwinsaul
-/src/main/java/com/estante/controller/        @erwinsaul
+/src/main/java/edu/sisinf/estante/dao/               @erwinsaul
+/src/main/java/edu/sisinf/estante/servicio/          @erwinsaul
+/src/main/java/edu/sisinf/estante/controller/        @erwinsaul
 
 # Documentación
 /docs/                                        @erwinsaul


### PR DESCRIPTION
## ¿Qué hace este PR?

Actualiza las rutas definidas en `.github/CODEOWNERS` para corregir referencias obsoletas al paquete `com.estante`.

Se reemplazaron las rutas antiguas por las rutas reales del proyecto bajo `edu/sisinf/estante`, manteniendo las reglas de revisión para los módulos existentes.

## Issue relacionado
Closes #637

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Se verificó la estructura actual del proyecto en `src/main/java/edu/sisinf/estante/` y se actualizaron las rutas de CODEOWNERS para apuntar a los paquetes existentes:

- `edu/sisinf/estante/dao`
- `edu/sisinf/estante/servicio`
- `edu/sisinf/estante/controller`