### PR TITLE
chore(ci): agregar verificación de actualización de CHANGELOG.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,26 @@ jobs:
             exit 1
           fi
           echo "✅ PR referencia un issue"
+          
       - name: Checkout del repositorio
         uses: actions/checkout@v4
+        
+      - name: Verificar actualización de CHANGELOG.md
+        if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
+        run: |
+          git fetch origin ${{ github.base_ref }}
 
+          archivos=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          if echo "$archivos" | grep -q "^src/main/java/"; then
+            if ! echo "$archivos" | grep -q "^CHANGELOG.md$"; then
+              echo "El PR modifica src/main/java pero no actualiza CHANGELOG.md"
+              echo "Agrega el cambio al CHANGELOG.md o usa la etiqueta skip-changelog si corresponde"
+              exit 1
+            fi
+          fi
+
+          echo "✅ Verificación de CHANGELOG.md correcta"
       - name: Verificar estructura Maven
         run: bash scripts/verificar_estructura.sh
 


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega una verificación en el workflow de CI para validar que los PRs que modifican archivos dentro de src/main/java también actualicen CHANGELOG.md.

Además, permite omitir esta verificación cuando el PR tenga aplicada la etiqueta skip-changelog.

## Issue relacionado
Closes #653

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

No aplica.