### PR TITLE
fix(build): activar failOnViolation en maven-checkstyle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
                     <configLocation>google_checks.xml</configLocation>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>false</failsOnError>
-                    <failOnViolation>false</failOnViolation>
+                    <failOnViolation>true</failOnViolation>
                     <violationSeverity>warning</violationSeverity>
                     <outputFile>${project.build.directory}/checkstyle-result.xml</outputFile>
                     <outputFileFormat>xml</outputFileFormat>


### PR DESCRIPTION
## ¿Qué hace este PR?

Actualiza la configuración del `maven-checkstyle-plugin` en `pom.xml` para que las violaciones de Checkstyle provoquen un fallo cuando se ejecute la verificación.

Se cambió únicamente la propiedad `failOnViolation` de `false` a `true`, manteniendo `failsOnError` en `false` según lo indicado en el issue.

## Issue relacionado
Closes #518

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Se modificó la configuración del plugin `maven-checkstyle-plugin` en `pom.xml`:

- `failOnViolation`: `false` → `true`
- `failsOnError` se mantuvo en `false`.