### PR TITLE
fix(util): formalizar isDML como alias documentado de esDML

### DIFF
--- a/src/main/java/edu/sisinf/estante/util/SqlValidator.java
+++ b/src/main/java/edu/sisinf/estante/util/SqlValidator.java
@@ -44,10 +44,19 @@ public class SqlValidator {
                 || tipo == TipoQuery.DELETE;
     }
 
-    // Este solo existe para que el test/issue #240 no falle
-    public static boolean isDML(String query) {
-    return esDML(query); 
-    }
+  /**
+   * Determina si la consulta corresponde a una operación DML.
+   *
+   * <p>Este método se mantiene como un alias de {@link #esDML(String)}
+   * para preservar la compatibilidad con el código existente.</p>
+   *
+   * @param query consulta SQL a evaluar
+   * @return {@code true} si la consulta corresponde a una operación DML;
+   *         {@code false} en caso contrario
+   */
+  public static boolean isDML(String query) {
+      return esDML(query);
+  }
 
     public static boolean esDDL(String query) {
         TipoQuery tipo = tipo(query);


### PR DESCRIPTION
## ¿Qué hace este PR?

Formaliza el método `isDML(String)` como parte de la API pública de `SqlValidator`.

Se eliminó el comentario temporal que indicaba que el método existía únicamente para hacer pasar un test y se agregó documentación Javadoc. El comportamiento del método no cambia, ya que continúa delegando en `esDML(String)` para mantener la compatibilidad con el código existente.

## Issue relacionado
Closes #517

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

- Se eliminó el comentario temporal del método `isDML(String)`.
- Se agregó documentación Javadoc para formalizar el método como parte de la API pública.
- Se mantuvo el mismo comportamiento del método, delegando la lógica a `esDML(String)`.