### PR TITLE
fix(module): exportar paquetes util, core, config y dto en module-info

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -34,4 +34,8 @@ module edu.sisinf.estante {
     exports edu.sisinf.estante.modelo;
     exports edu.sisinf.estante.servicio;
     exports edu.sisinf.estante.dao;
+    exports edu.sisinf.estante.util;
+    exports edu.sisinf.estante.core;
+    exports edu.sisinf.estante.config;
+    exports edu.sisinf.estante.dto;
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Exporta los paquetes `edu.sisinf.estante.util`, `edu.sisinf.estante.core`, `edu.sisinf.estante.config` y `edu.sisinf.estante.dto` en el archivo `module-info.java`. Esto corrige la visibilidad de los paquetes para permitir el acceso reflexivo y la modularización adecuada, según los requerimientos del issue.

## Issue relacionado
Closes #527

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se han añadido las directivas `exports` correspondientes a los paquetes faltantes en `src/main/java/module-info.java`, manteniendo la estructura y estilo del archivo.