### PR TITLE
fix(core): registrar ConexionDAOPostgreSQL en el mapa de DAOs

### DIFF
--- a/src/main/java/edu/sisinf/estante/App.java
+++ b/src/main/java/edu/sisinf/estante/App.java
@@ -61,6 +61,10 @@ public class App extends Application {
         daos.put(
                 TipoMotor.MYSQL,
                 new ConexionDAOMySQL()
+            daos.put(
+        TipoMotor.POSTGRESQL,
+        new ConexionDAOPostgreSQL()
+    );
         );
 
         repositorio = new RepositorioConexionesJSON(


### PR DESCRIPTION
## ¿Qué hace este PR?
Registra `ConexionDAOPostgreSQL` en el mapa de DAOs dentro de `App.java` para solucionar el `NullPointerException` al seleccionar el motor PostgreSQL.

## Issue relacionado
Closes #511

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Registro de motor añadido en App.java siguiendo el patrón de los otros motores.